### PR TITLE
Wait for all data to be sent before returning it

### DIFF
--- a/waitress/tests/test_functional.py
+++ b/waitress/tests/test_functional.py
@@ -1241,14 +1241,13 @@ def read_http(fp): # pragma: no cover
     if 'content-length' in headers:
         num = int(headers['content-length'])
         body = b''
-        read = 0
-        while 1:
-            left = num - read
+        left = num
+        while left > 0:
             data = fp.read(left)
             if not data:
                 break
             body += data
-            read += len(data)
+            left -= len(data)
     else:
         # read until EOF
         body = fp.read()


### PR DESCRIPTION
As Lorenzo Gil Sanchez [reported](https://groups.google.com/forum/?hl=fr&fromgroups=#!topic/pylons-devel/AFgtDJ9HsV4), tests in `test_functional.TestFileWrapper` may sometimes fail like this:

```
Traceback (most recent call last):
  File "/home/damien/dev/waitress/waitress/tests/test_functional.py", line 1043, in test_filelike_longcl_http11
    self.assertEqual(cl, len(response_body))
AssertionError: 45448 != 18000
```

I could reproduce these test failures on a rather low-end machine. They happen because the data is read from the socket before everything has been sent. The current implementation of `read_http()` tries to read N bytes; if less than N bytes have been sent at this point, the function returns nevertheless, not waiting for the rest of the data, hence the test failures.

The attached patch should work around this. (Note: this is a "bug" in the tests, not in the implementation.)
