### PR TITLE
Removed a warning that was displayed for HEAD requests.

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -418,11 +418,12 @@ class WSGITask(Task):
                     # waiting for more data when there are too few bytes
                     # to service content-length
                     self.close_on_finish = True
-                    self.logger.warning(
-                        'application returned too few bytes (%s) '
-                        'for specified Content-Length (%s) via app_iter' % (
-                            self.content_bytes_written, cl),
-                        )
+                    if self.request.command != 'HEAD':
+                        self.logger.warning(
+                            'application returned too few bytes (%s) '
+                            'for specified Content-Length (%s) via app_iter' % (
+                                self.content_bytes_written, cl),
+                            )
         finally:
             if hasattr(app_iter, 'close'):
                 app_iter.close()

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -457,6 +457,18 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(inst.close_on_finish, True)
         self.assertEqual(len(inst.logger.logged), 1)
 
+    def test_execute_app_do_not_warn_on_head(self):
+        def app(environ, start_response):
+            start_response('200 OK', [('Content-Length', '3')])
+            return [b'']
+        inst = self._makeOne()
+        inst.request.command = 'HEAD'
+        inst.channel.server.application = app
+        inst.logger = DummyLogger()
+        inst.execute()
+        self.assertEqual(inst.close_on_finish, True)
+        self.assertEqual(len(inst.logger.logged), 0)
+
     def test_execute_app_returns_closeable(self):
         class closeable(list):
             def close(self):


### PR DESCRIPTION
> application returned too few bytes (0) for specified Content-Length (85506) via app_iter

I kept getting this warning when doing HEAD requests, but it seems normal to me to get no content in a head request. I made waitress check if the request is a HEAD before issuing the warning.

This patch comes with a test, and a little fix to the tests (first of the two commits).
