### PR TITLE
Missing additional Unix socket documentation.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,7 @@
 
 .. module:: waitress
 
-.. function:: serve(app, host='0.0.0.0', port=8080, threads=4, url_scheme='http', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=18000, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
+.. function:: serve(app, host='0.0.0.0', port=8080, unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=18000, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
 
      See :ref:`arguments` for more information.
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -18,6 +18,8 @@ unix_socket
     specified, a Unix domain socket is made instead of the usual inet domain
     socket.
 
+    Not available on Windows.
+
 unix_socket_perms
     Octal permissions to use for the Unix domain socket (string), default is
     ``600``. Only used if ``unix_socket`` is not ``None``.


### PR DESCRIPTION
I'd forgotten to add the additional arguments to the signature of waitress.serve(). Also, I think it's worth noting in the docs that Unix domain sockets are not supported on Windows.
