### PR TITLE
Generalise multiprocess test execution.

### DIFF
--- a/waitress/tests/support.py
+++ b/waitress/tests/support.py
@@ -2,31 +2,12 @@
 Support code for tests.
 """
 
+import getopt
 import logging
-import os
 import sys
 
 import waitress
 
-PID = os.getpid()
-port = os.environ.get('WAITRESS_TEST_PORT')
-if port is None:  # main process
-    # To permit parallel testing under 'detox', use a PID-dependent port:
-    # Subtract least-significant 20 bits of the PID from the top of the
-    # allowed port range
-    TEST_PORT = 0xffff - (PID & 0x7ff)
-    TEST_SOCKET_PATH = '/tmp/waitress.test-%d.sock' % PID
-    os.environ['WAITRESS_TEST_PORT'] = str(TEST_PORT)
-else:               # pragma NO COVER subprocess
-    TEST_PORT = int(port)
-
-socket = os.environ.get('WAITRESS_TEST_SOCKET')
-if socket is None:  # main process
-    # To permit parallel testing under 'detox', use a PID-dependent socket.
-    TEST_SOCKET_PATH = '/tmp/waitress.test-%d.sock' % PID
-    os.environ['WAITRESS_TEST_SOCKET'] = TEST_SOCKET_PATH
-else:               # pragma NO COVER subprocess
-    TEST_SOCKET_PATH = socket
 
 class NullHandler(logging.Handler):  # pragma: no cover
     """A logging handler that swallows all emitted messages."""
@@ -34,13 +15,24 @@ class NullHandler(logging.Handler):  # pragma: no cover
         pass
 
 def start_server(app, **kwargs):  # pragma: no cover
-    """Run a fixture application."""
-    if len(sys.argv) == 2 and sys.argv[1] == '-u':
-        kwargs.update({
-            'unix_socket': TEST_SOCKET_PATH,
-            'unix_socket_perms': '600',
-        })
-    else:
-        kwargs['port'] = TEST_PORT
-    logging.getLogger('waitress').addHandler(NullHandler())
-    waitress.serve(app, _quiet=True, **kwargs)
+    """Run a fixture application.
+
+    There are three flags: `-p` to specify a port to listen on, `-u` to
+    specify a Unix socket to listen on, and `-l` prevent logging from being
+    disabled.
+    """
+    opts, _args = getopt.getopt(sys.argv[1:], 'p:u:v')
+    quiet = True
+    for opt, value in opts:
+        if opt == '-p':
+            kwargs['port'] = int(value)
+        elif opt == '-u':
+            kwargs.update({
+                'unix_socket': value,
+                'unix_socket_perms': '600',
+            })
+        elif opt == '-v':
+            quiet = False
+    if quiet:
+        logging.getLogger('waitress').addHandler(NullHandler())
+    waitress.serve(app, _quiet=quiet, **kwargs)


### PR DESCRIPTION
The previous method worked fine under detox, but didn't allow nose's --processes=? flag to be used. This method uses a more general method which allows both.

For instance, running "nosetests --processes=4 waitress.tests" with this patch reduces running time down from 60s to 16s
