### PR TITLE
autopep8 runthrough and janitorial changes.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,7 +8,3 @@
 .. function:: serve(app, host='0.0.0.0', port=8080, unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=18000, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
 
      See :ref:`arguments` for more information.
-
-
-
-

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -58,7 +58,7 @@ send_bytes
 outbuf_overflow
     A tempfile should be created if the pending output is larger than
     outbuf_overflow, which is measured in bytes. The default is 1MB
-    (``104856``).  This is conservative.
+    (``1048576``).  This is conservative.
 
 inbuf_overflow
     A tempfile should be created if the pending input is larger than
@@ -86,7 +86,7 @@ channel_timeout
     ``120``.  "Inactive" is defined as "has received no data from a client
     and has sent no data to a client".
 
-log_socket_errors 
+log_socket_errors
     Boolean: turn off to not log premature client disconnect tracebacks.
     Default: ``True``.
 
@@ -105,4 +105,3 @@ expose_tracebacks
 asyncore_loop_timeout
     The ``timeout`` value (seconds) passed to ``asyncore.loop`` to run the
     mainloop.  Default: 1.  (New in 0.8.3.)
-

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -52,4 +52,3 @@ entirely.
 Periodic maintenance is done by the main thread (the thread handling I/O).
 If a channel hasn't sent or received any data in a while, the channel's
 connection is closed, and the channel is destroyed.
-

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -13,5 +13,3 @@ Glossary
    asyncore
       A standard library module for asynchronous communications.  See
       http://docs.python.org/library/asyncore.html .
-
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -263,4 +263,3 @@ fork.  ``zope.server`` has existed in one form or another since about 2001,
 and has seen production usage since then, so Waitress is not exactly
 "another" server, it's more a repackaging of an old one that was already
 known to work fairly well.
-

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,12 @@ except IOError:
 docs_extras = [
     'Sphinx',
     'docutils',
-    ]
+]
 
 testing_extras = [
     'nose',
     'coverage',
-    ]
+]
 
 setup(
     name='waitress',
@@ -39,10 +39,10 @@ setup(
     maintainer="Chris McDonough",
     maintainer_email="chrism@plope.com",
     description='Waitress WSGI server',
-    long_description = README +'\n\n' + CHANGES,
+    long_description=README + '\n\n' + CHANGES,
     license='ZPL 2.1',
     keywords='waitress wsgi server http',
-    classifiers = [
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -59,16 +59,16 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
-        ],
+    ],
     url='https://github.com/Pylons/waitress',
     packages=find_packages(),
     install_requires=[
         'setuptools',
-        ],
-    extras_require = {
-        'testing':testing_extras,
-        'docs':docs_extras,
-        },
+    ],
+    extras_require={
+        'testing': testing_extras,
+        'docs': docs_extras,
+    },
     include_package_data=True,
     test_suite='waitress',
     zip_safe=False,
@@ -76,4 +76,4 @@ setup(
     [paste.server_runner]
     main = waitress:serve_paste
     """
-    )
+)

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -19,6 +19,7 @@ import sys
 class Adjustments(object):
     """This class contains tunable parameters.
     """
+
     # hostname or IP address to listen on
     host = '0.0.0.0'
 
@@ -102,7 +103,7 @@ class Adjustments(object):
     # algorithm for writes (Waitress already buffers its writes).
     socket_options = [
         (socket.SOL_TCP, socket.TCP_NODELAY, 1),
-        ]
+    ]
 
     # The asyncore.loop timeout value
     asyncore_loop_timeout = 1
@@ -153,8 +154,8 @@ class Adjustments(object):
                 raise ValueError('Unknown adjustment %r' % k)
             setattr(self, k, v)
         if (sys.platform[:3] == "win" and
-            self.host == 'localhost' ): # pragma: no cover
-            self.host= ''
+                self.host == 'localhost'): # pragma: no cover
+            self.host = ''
 
 truthy = frozenset(('t', 'true', 'y', 'yes', 'on', '1'))
 
@@ -170,4 +171,3 @@ def asbool(s):
         return s
     s = str(s).strip()
     return s.lower() in truthy
-

--- a/waitress/buffers.py
+++ b/waitress/buffers.py
@@ -16,11 +16,10 @@
 from io import BytesIO
 
 # copy_bytes controls the size of temp. strings for shuffling data around.
-COPY_BYTES = 1 << 18  # 256K
+COPY_BYTES = 1 << 18 # 256K
 
 # The maximum number of bytes to buffer in a simple string.
 STRBUF_LIMIT = 8192
-
 
 class FileBasedBuffer(object):
 
@@ -32,7 +31,7 @@ class FileBasedBuffer(object):
             from_file = from_buffer.getfile()
             read_pos = from_file.tell()
             from_file.seek(0)
-            while 1:
+            while True:
                 data = from_file.read(COPY_BYTES)
                 if not data:
                     break
@@ -76,7 +75,7 @@ class FileBasedBuffer(object):
         if self.remain < numbytes:
             raise ValueError("Can't skip %d bytes in buffer of %d bytes" % (
                 numbytes, self.remain)
-                )
+            )
         self.file.seek(numbytes, 1)
         self.remain = self.remain - numbytes
 
@@ -94,7 +93,7 @@ class FileBasedBuffer(object):
                 # Nothing to prune.
                 return
         nf = self.newfile()
-        while 1:
+        while True:
             data = file.read(COPY_BYTES)
             if not data:
                 break
@@ -120,8 +119,6 @@ class TempfileBasedBuffer(FileBasedBuffer):
         from tempfile import TemporaryFile
         return TemporaryFile('w+b')
 
-
-
 class BytesIOBasedBuffer(FileBasedBuffer):
 
     def __init__(self, from_buffer=None):
@@ -134,15 +131,15 @@ class BytesIOBasedBuffer(FileBasedBuffer):
     def newfile(self):
         return BytesIO()
 
-class ReadOnlyFileBasedBuffer(FileBasedBuffer): 
+class ReadOnlyFileBasedBuffer(FileBasedBuffer):
     # used as wsgi.file_wrapper
+
     def __init__(self, file, block_size=32768):
         self.file = file
         self.block_size = block_size # for __iter__
 
     def prepare(self, size=None):
-        if ( hasattr(self.file, 'seek') and
-             hasattr(self.file, 'tell') ):
+        if hasattr(self.file, 'seek') and hasattr(self.file, 'tell'):
             start_pos = self.file.tell()
             self.file.seek(0, 2)
             end_pos = self.file.tell()
@@ -181,7 +178,7 @@ class ReadOnlyFileBasedBuffer(FileBasedBuffer):
         return val
 
     __next__ = next # py3
-    
+
     def append(self, s):
         raise NotImplementedError
 
@@ -197,7 +194,7 @@ class OverflowableBuffer(object):
 
     overflowed = False
     buf = None
-    strbuf = b''  # Bytes-based buffer.
+    strbuf = b'' # Bytes-based buffer.
 
     def __init__(self, overflow):
         # overflow is the maximum to be stored in a StringIO buffer.
@@ -296,4 +293,3 @@ class OverflowableBuffer(object):
         buf = self.buf
         if buf is not None:
             buf._close()
-            

--- a/waitress/channel.py
+++ b/waitress/channel.py
@@ -19,7 +19,7 @@ import traceback
 from waitress.buffers import (
     OverflowableBuffer,
     ReadOnlyFileBasedBuffer,
-    )
+)
 
 from waitress.parser import HTTPRequestParser
 
@@ -28,12 +28,12 @@ from waitress.compat import thread
 from waitress.task import (
     ErrorTask,
     WSGITask,
-    )
+)
 
 from waitress.utilities import (
     logging_dispatcher,
     InternalServerError,
-    )
+)
 
 class HTTPChannel(logging_dispatcher, object):
     """
@@ -42,6 +42,7 @@ class HTTPChannel(logging_dispatcher, object):
 
     Setting self.requests = [] allows more requests to be received.
     """
+
     task_class = WSGITask
     error_task_class = ErrorTask
     parser_class = HTTPRequestParser
@@ -64,15 +65,14 @@ class HTTPChannel(logging_dispatcher, object):
             sock,
             addr,
             adj,
-            map=None,
-            ):
+            map=None):
         self.server = server
         self.adj = adj
         self.outbufs = [OverflowableBuffer(adj.outbuf_overflow)]
         self.creation_time = self.last_activity = time.time()
 
         # task_lock used to push/pop requests
-        self.task_lock = thread.allocate_lock() 
+        self.task_lock = thread.allocate_lock()
         # outbuf_lock used to access any outbuf
         self.outbuf_lock = thread.allocate_lock()
 

--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -45,10 +45,12 @@ if PY3: # pragma: no cover
         if isinstance(s, text_type):
             s = s.encode('latin-1')
         return str(s, 'latin-1', 'strict')
+
     def tobytes(s):
         return bytes(s, 'latin-1')
 else:
     tostr = str
+
     def tobytes(s):
         return s
 
@@ -56,18 +58,17 @@ try:
     from Queue import (
         Queue,
         Empty,
-        )
+    )
 except ImportError: # pragma: no cover
     from queue import (
         Queue,
         Empty,
-        )
+    )
 
 try:
     import thread
 except ImportError: # pragma: no cover
     import _thread as thread
-    
 
 if PY3: # pragma: no cover
     import builtins
@@ -79,7 +80,6 @@ if PY3: # pragma: no cover
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
         raise value
-
 
     del builtins
 
@@ -96,13 +96,11 @@ else: # pragma: no cover
             locs = globs
         exec("""exec code in globs, locs""")
 
-
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
 
-
-try: 
+try:
     from StringIO import StringIO as NativeIO
 except ImportError: # pragma: no cover
     from io import StringIO as NativeIO
@@ -111,4 +109,3 @@ try:
     import httplib
 except ImportError: # pragma: no cover
     from http import client as httplib
-    

--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -23,21 +23,21 @@ from waitress.compat import (
     tostr,
     urlparse,
     unquote_bytes_to_wsgi,
-    )
+)
 
 from waitress.buffers import OverflowableBuffer
 
 from waitress.receiver import (
     FixedStreamReceiver,
     ChunkedReceiver,
-    )
+)
 
 from waitress.utilities import (
     find_double_newline,
     RequestEntityTooLarge,
     RequestHeaderFieldsTooLarge,
     BadRequest,
-    )
+)
 
 class ParsingError(Exception):
     pass
@@ -50,8 +50,8 @@ class HTTPRequestParser(object):
 
     """
 
-    completed = False  # Set once request is completed.
-    empty = False        # Set if no request was made.
+    completed = False # Set once request is completed.
+    empty = False # Set if no request was made.
     expect_continue = False # client sent "Expect: 100-continue" header
     headers_finished = False # True when headers have been read
     header_plus = b''
@@ -83,7 +83,7 @@ class HTTPRequestParser(object):
         body have been received.
         """
         if self.completed:
-            return 0  # Can't consume any more.
+            return 0 # Can't consume any more.
         datalen = len(data)
         br = self.body_rcv
         if br is None:
@@ -175,7 +175,7 @@ class HTTPRequestParser(object):
                 key1 = tostr(key.upper().replace(b'-', b'_'))
                 # If a header already exists, we append subsequent values
                 # seperated by a comma. Applications already need to handle
-                # the comma seperated values, as HTTP front ends might do 
+                # the comma seperated values, as HTTP front ends might do
                 # the concatenation for you (behavior specified in RFC2616).
                 try:
                     headers[key1] += tostr(b', ' + value)
@@ -243,7 +243,7 @@ def split_uri(uri):
         unquote_bytes_to_wsgi(path),
         tostr(query),
         tostr(fragment),
-        )
+    )
 
 def get_header_lines(header):
     """
@@ -262,7 +262,7 @@ def get_header_lines(header):
     return r
 
 first_line_re = re.compile(
-b'([^ ]+) ((?:[^ :?#]+://[^ ?#/]*(?:[0-9]{1,5})?)?[^ ]+)(( HTTP/([0-9.]+))$|$)')
+    b'([^ ]+) ((?:[^ :?#]+://[^ ?#/]*(?:[0-9]{1,5})?)?[^ ]+)(( HTTP/([0-9.]+))$|$)')
 
 def crack_first_line(line):
     m = first_line_re.match(line)

--- a/waitress/receiver.py
+++ b/waitress/receiver.py
@@ -32,7 +32,7 @@ class FixedStreamReceiver(object):
         'See IStreamConsumer'
         rm = self.remain
         if rm < 1:
-            self.completed = True  # Avoid any chance of spinning
+            self.completed = True # Avoid any chance of spinning
             return 0
         datalen = len(data)
         if rm <= datalen:
@@ -62,7 +62,6 @@ class ChunkedReceiver(object):
 
     # max_control_line = 1024
     # max_trailer = 65536
-
 
     def __init__(self, buf):
         self.buf = buf
@@ -102,7 +101,7 @@ class ChunkedReceiver(object):
                             # discard extension info.
                             line = line[:semi]
                         try:
-                            sz = int(line.strip(), 16)  # hexadecimal
+                            sz = int(line.strip(), 16) # hexadecimal
                         except ValueError: # garbage in input
                             self.error = BadRequest(
                                 'garbage in chunked encoding input')
@@ -137,10 +136,8 @@ class ChunkedReceiver(object):
                     return orig_size - (len(trailer) - pos)
         return orig_size
 
-
     def getfile(self):
         return self.buf.getfile()
 
     def getbuf(self):
         return self.buf
-    

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -26,10 +26,10 @@ from waitress.utilities import cleanup_unix_socket, logging_dispatcher
 
 def WSGIServer(application,
                map=None,
-               _start=True, # test shim
-               _sock=None,  # test shim
+               _start=True,      # test shim
+               _sock=None,       # test shim
                _dispatcher=None, # test shim
-               **kw # adjustments
+               **kw              # adjustments
                ):
     """
     if __name__ == '__main__':
@@ -54,10 +54,10 @@ class BaseWSGIServer(logging_dispatcher, object):
     def __init__(self,
                  application,
                  map,
-                 _start, # test shim
-                 _sock,  # test shim
+                 _start,      # test shim
+                 _sock,       # test shim
                  _dispatcher, # test shim
-                 adj # adjustments
+                 adj          # adjustments
                  ):
 
         self.application = application
@@ -79,7 +79,7 @@ class BaseWSGIServer(logging_dispatcher, object):
             self.accept_connections()
 
     def bind_server_socket(self):
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError # pragma: no cover
 
     def get_server_name(self, ip):
         """Given an IP or hostname, try to determine the server name."""
@@ -100,11 +100,11 @@ class BaseWSGIServer(logging_dispatcher, object):
         return server_name
 
     def getsockname(self):
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError # pragma: no cover
 
     def accept_connections(self):
         self.accepting = True
-        self.socket.listen(self.adj.backlog)  # Get around asyncore NT limit
+        self.socket.listen(self.adj.backlog) # Get around asyncore NT limit
 
     def add_task(self, task):
         self.task_dispatcher.add_task(task)
@@ -149,7 +149,7 @@ class BaseWSGIServer(logging_dispatcher, object):
             self.asyncore.loop(
                 timeout=self.adj.asyncore_loop_timeout,
                 map=self._map
-                )
+            )
         except (SystemExit, KeyboardInterrupt):
             self.task_dispatcher.shutdown()
 

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -24,18 +24,18 @@ from waitress.compat import (
     Empty,
     thread,
     reraise,
-    )
+)
 
 from waitress.utilities import (
     build_http_date,
     logger,
-    )
+)
 
 rename_headers = {
-    'CONTENT_LENGTH' : 'CONTENT_LENGTH',
-    'CONTENT_TYPE'   : 'CONTENT_TYPE',
-    'CONNECTION'     : 'CONNECTION_TYPE',
-    }
+    'CONTENT_LENGTH': 'CONTENT_LENGTH',
+    'CONTENT_TYPE': 'CONTENT_TYPE',
+    'CONNECTION': 'CONNECTION_TYPE',
+}
 
 hop_by_hop = frozenset((
     'connection',
@@ -46,7 +46,7 @@ hop_by_hop = frozenset((
     'trailers',
     'transfer-encoding',
     'upgrade'
-    ))
+))
 
 class JustTesting(Exception):
     pass
@@ -55,12 +55,12 @@ class ThreadedTaskDispatcher(object):
     """A Task Dispatcher that creates a thread for each task.
     """
 
-    stop_count = 0  # Number of threads that will stop soon.
+    stop_count = 0 # Number of threads that will stop soon.
     start_new_thread = thread.start_new_thread
     logger = logger
 
     def __init__(self):
-        self.threads = {}  # { thread number -> 1 }
+        self.threads = {} # { thread number -> 1 }
         self.queue = Queue()
         self.thread_mgmt_lock = thread.allocate_lock()
 
@@ -128,7 +128,9 @@ class ThreadedTaskDispatcher(object):
         expiration = time.time() + timeout
         while threads:
             if time.time() >= expiration:
-                self.logger.warning("%d thread(s) still running" % len(threads))
+                self.logger.warning(
+                    "%d thread(s) still running" %
+                    len(threads))
                 break
             time.sleep(0.1)
         if cancel_pending:
@@ -198,7 +200,7 @@ class Task(object):
         for i, (headername, headerval) in enumerate(response_headers):
             headername = '-'.join(
                 [x.capitalize() for x in headername.split('-')]
-                )
+            )
             if headername == 'Content-Length':
                 content_length_header = headerval
             if headername == 'Date':
@@ -214,7 +216,7 @@ class Task(object):
             content_length_header = str(self.content_length)
             self.response_headers.append(
                 ('Content-Length', content_length_header)
-                )
+            )
 
         def close_on_finish():
             if connection_close_header is None:
@@ -292,7 +294,7 @@ class Task(object):
                 towrite = tobytes(hex(len(data))[2:].upper()) + b'\r\n'
                 towrite += data + b'\r\n'
             elif cl is not None:
-                towrite = data[:cl-self.content_bytes_written]
+                towrite = data[:cl - self.content_bytes_written]
                 self.content_bytes_written += len(towrite)
                 if towrite != data and not self.logged_write_excess:
                     self.logger.warning(
@@ -304,7 +306,9 @@ class Task(object):
 
 class ErrorTask(Task):
     """ An error task produces an error response """
+
     complete = True
+
     def execute(self):
         e = self.request.error
         body = '%s\r\n\r\n%s' % (e.reason, e.body)
@@ -358,11 +362,11 @@ class WSGITask(Task):
                 if not k.__class__ is str:
                     raise AssertionError(
                         'Header name %r is not a string in %r' % (k, (k, v))
-                        )
+                    )
                 if not v.__class__ is str:
                     raise AssertionError(
                         'Header value %r is not a string in %r' % (v, (k, v))
-                        )
+                    )
                 kl = k.lower()
                 if kl == 'content-length':
                     self.content_length = int(v)
@@ -423,7 +427,7 @@ class WSGITask(Task):
                             'application returned too few bytes (%s) '
                             'for specified Content-Length (%s) via app_iter' % (
                                 self.content_bytes_written, cl),
-                            )
+                        )
         finally:
             if hasattr(app_iter, 'close'):
                 app_iter.close()
@@ -463,7 +467,7 @@ class WSGITask(Task):
                 environ[mykey] = value
 
         # the following environment variables are required by the WSGI spec
-        environ['wsgi.version'] = (1,0)
+        environ['wsgi.version'] = (1, 0)
         environ['wsgi.url_scheme'] = request.url_scheme
         environ['wsgi.errors'] = sys.stderr # apps should use the logging module
         environ['wsgi.multithread'] = True
@@ -474,4 +478,3 @@ class WSGITask(Task):
 
         self.environ = environ
         return environ
-

--- a/waitress/tests/fixtureapps/badcl.py
+++ b/waitress/tests/fixtureapps/badcl.py
@@ -2,13 +2,13 @@ def app(environ, start_response):
     body = b'abcdefghi'
     cl = len(body)
     if environ['PATH_INFO'] == '/short_body':
-        cl = len(body) +1
+        cl = len(body) + 1
     if environ['PATH_INFO'] == '/long_body':
-        cl = len(body) -1
+        cl = len(body) - 1
     start_response(
         '200 OK',
         [('Content-Length', str(cl)), ('Content-Type', 'text/plain')]
-        )
+    )
     return [body]
 
 if __name__ == '__main__':

--- a/waitress/tests/fixtureapps/echo.py
+++ b/waitress/tests/fixtureapps/echo.py
@@ -7,7 +7,7 @@ def app(environ, start_response):
     start_response(
         '200 OK',
         [('Content-Length', cl), ('Content-Type', 'text/plain')]
-        )
+    )
     return [body]
 
 if __name__ == '__main__':

--- a/waitress/tests/fixtureapps/error.py
+++ b/waitress/tests/fixtureapps/error.py
@@ -9,7 +9,7 @@ def app(environ, start_response):
     write = start_response(
         '200 OK',
         [('Content-Length', cl), ('Content-Type', 'text/plain')]
-        )
+    )
     if environ['PATH_INFO'] == '/after_write_cb':
         write('abc')
     if environ['PATH_INFO'] == '/in_generator':

--- a/waitress/tests/fixtureapps/filewrapper.py
+++ b/waitress/tests/fixtureapps/filewrapper.py
@@ -4,6 +4,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 fn = os.path.join(here, 'groundhog1.jpg')
 
 class KindaFilelike(object):
+
     def __init__(self, bytes):
         self.bytes = bytes
 
@@ -21,45 +22,51 @@ def app(environ, start_response):
         f.seek(0)
         if path_info == '/filelike':
             headers = [
-                ('Content-Length', str(cl)), ('Content-Type', 'image/jpeg')
-                ]
+                ('Content-Length', str(cl)),
+                ('Content-Type', 'image/jpeg'),
+            ]
         elif path_info == '/filelike_nocl':
             headers = [('Content-Type', 'image/jpeg')]
         elif path_info == '/filelike_shortcl':
             # short content length
             headers = [
-                ('Content-Length', '1'), ('Content-Type', 'image/jpeg')
-                ]
+                ('Content-Length', '1'),
+                ('Content-Type', 'image/jpeg'),
+            ]
         else:
             # long content length (/filelike_longcl)
             headers = [
-                ('Content-Length', str(cl+10)), ('Content-Type', 'image/jpeg')
-                ]
+                ('Content-Length', str(cl + 10)),
+                ('Content-Type', 'image/jpeg'),
+            ]
     else:
         data = open(fn, 'rb').read()
         cl = len(data)
         f = KindaFilelike(data)
         if path_info == '/notfilelike':
-            headers =  [('Content-Length', str(len(data))),
-                        ('Content-Type', 'image/jpeg')]
-
+            headers = [
+                ('Content-Length', str(len(data))),
+                ('Content-Type', 'image/jpeg'),
+            ]
         elif path_info == '/notfilelike_nocl':
             headers = [('Content-Type', 'image/jpeg')]
         elif path_info == '/notfilelike_shortcl':
             # short content length
             headers = [
-                ('Content-Length', '1'), ('Content-Type', 'image/jpeg')
-                ]
+                ('Content-Length', '1'),
+                ('Content-Type', 'image/jpeg'),
+            ]
         else:
             # long content length (/notfilelike_longcl)
             headers = [
-                ('Content-Length', str(cl+10)), ('Content-Type', 'image/jpeg')
-                ]
+                ('Content-Length', str(cl + 10)),
+                ('Content-Type', 'image/jpeg'),
+            ]
 
     start_response(
         '200 OK',
         headers
-        )
+    )
     return environ['wsgi.file_wrapper'](f, 8192)
 
 if __name__ == '__main__':

--- a/waitress/tests/fixtureapps/getline.py
+++ b/waitress/tests/fixtureapps/getline.py
@@ -2,14 +2,13 @@ import sys
 
 if __name__ == '__main__':
     try:
-        from urllib.request import Request, urlopen
+        from urllib.request import urlopen
     except ImportError:
-        from urllib2 import Request, urlopen
+        from urllib2 import urlopen
 
     url = sys.argv[1]
-    headers = {'Content-Type':'text/plain; charset=utf-8'}
+    headers = {'Content-Type': 'text/plain; charset=utf-8'}
     resp = urlopen(url)
     line = resp.readline().decode('ascii') # py3
     sys.stdout.write(line)
     sys.stdout.flush()
-    

--- a/waitress/tests/fixtureapps/nocl.py
+++ b/waitress/tests/fixtureapps/nocl.py
@@ -2,7 +2,7 @@ def chunks(l, n):
     """ Yield successive n-sized chunks from l.
     """
     for i in range(0, len(l), n):
-        yield l[i:i+n]
+        yield l[i:i + n]
 
 def gen(body):
     for chunk in chunks(body, 10):
@@ -16,7 +16,7 @@ def app(environ, start_response):
     start_response(
         '200 OK',
         [('Content-Type', 'text/plain')]
-        )
+    )
     if environ['PATH_INFO'] == '/list':
         return [body]
     if environ['PATH_INFO'] == '/list_lentwo':

--- a/waitress/tests/fixtureapps/sleepy.py
+++ b/waitress/tests/fixtureapps/sleepy.py
@@ -10,7 +10,7 @@ def app(environ, start_response):
     start_response(
         '200 OK',
         [('Content-Length', cl), ('Content-Type', 'text/plain')]
-        )
+    )
     return [body]
 
 if __name__ == '__main__':

--- a/waitress/tests/fixtureapps/toolarge.py
+++ b/waitress/tests/fixtureapps/toolarge.py
@@ -4,7 +4,7 @@ def app(environ, start_response):
     start_response(
         '200 OK',
         [('Content-Length', str(cl)), ('Content-Type', 'text/plain')]
-        )
+    )
     return [body]
 
 if __name__ == '__main__':

--- a/waitress/tests/support.py
+++ b/waitress/tests/support.py
@@ -10,30 +10,31 @@ import waitress
 
 PID = os.getpid()
 port = os.environ.get('WAITRESS_TEST_PORT')
-if port is None:  # main process
+if port is None: # main process
     # To permit parallel testing under 'detox', use a PID-dependent port:
     # Subtract least-significant 20 bits of the PID from the top of the
     # allowed port range
     TEST_PORT = 0xffff - (PID & 0x7ff)
     TEST_SOCKET_PATH = '/tmp/waitress.test-%d.sock' % PID
     os.environ['WAITRESS_TEST_PORT'] = str(TEST_PORT)
-else:               # pragma NO COVER subprocess
+else:            # pragma NO COVER subprocess
     TEST_PORT = int(port)
 
 socket = os.environ.get('WAITRESS_TEST_SOCKET')
-if socket is None:  # main process
+if socket is None: # main process
     # To permit parallel testing under 'detox', use a PID-dependent socket.
     TEST_SOCKET_PATH = '/tmp/waitress.test-%d.sock' % PID
     os.environ['WAITRESS_TEST_SOCKET'] = TEST_SOCKET_PATH
-else:               # pragma NO COVER subprocess
+else:              # pragma NO COVER subprocess
     TEST_SOCKET_PATH = socket
 
-class NullHandler(logging.Handler):  # pragma: no cover
+class NullHandler(logging.Handler): # pragma: no cover
     """A logging handler that swallows all emitted messages."""
+
     def emit(self, record):
         pass
 
-def start_server(app, **kwargs):  # pragma: no cover
+def start_server(app, **kwargs): # pragma: no cover
     """Run a fixture application."""
     if len(sys.argv) == 2 and sys.argv[1] == '-u':
         kwargs.update({

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -1,6 +1,7 @@
 import unittest
 
 class Test_asbool(unittest.TestCase):
+
     def _callFUT(self, s):
         from waitress.adjustments import asbool
         return asbool(s)
@@ -8,11 +9,11 @@ class Test_asbool(unittest.TestCase):
     def test_s_is_None(self):
         result = self._callFUT(None)
         self.assertEqual(result, False)
-        
+
     def test_s_is_True(self):
         result = self._callFUT(True)
         self.assertEqual(result, True)
-        
+
     def test_s_is_False(self):
         result = self._callFUT(False)
         self.assertEqual(result, False)
@@ -38,10 +39,11 @@ class Test_asbool(unittest.TestCase):
         self.assertEqual(result, True)
 
 class TestAdjustments(unittest.TestCase):
+
     def _makeOne(self, **kw):
         from waitress.adjustments import Adjustments
         return Adjustments(**kw)
-    
+
     def test_goodvars(self):
         inst = self._makeOne(
             host='host', port='8080', threads='5',
@@ -75,4 +77,3 @@ class TestAdjustments(unittest.TestCase):
 
     def test_badvar(self):
         self.assertRaises(ValueError, self._makeOne, nope=True)
-

--- a/waitress/tests/test_buffers.py
+++ b/waitress/tests/test_buffers.py
@@ -2,14 +2,15 @@ import unittest
 import io
 
 class TestFileBasedBuffer(unittest.TestCase):
+
     def _makeOne(self, file=None, from_buffer=None):
         from waitress.buffers import FileBasedBuffer
         return FileBasedBuffer(file, from_buffer=from_buffer)
-        
+
     def test_ctor_from_buffer_None(self):
         inst = self._makeOne('file')
         self.assertEqual(inst.file, 'file')
-        
+
     def test_ctor_from_buffer(self):
         from_buffer = io.BytesIO(b'data')
         from_buffer.getfile = lambda *x: from_buffer
@@ -45,7 +46,7 @@ class TestFileBasedBuffer(unittest.TestCase):
         result = inst.get(100, skip=True)
         self.assertEqual(result, b'data')
         self.assertEqual(inst.remain, -4)
-        
+
     def test_get_skip_false(self):
         f = io.BytesIO(b'data')
         inst = self._makeOne(f)
@@ -86,7 +87,7 @@ class TestFileBasedBuffer(unittest.TestCase):
         inst.prune()
         self.assertTrue(inst.file is not f)
         self.assertEqual(nf.getvalue(), b'd')
-        
+
     def test_prune_remain_zero_tell_notzero(self):
         f = io.BytesIO(b'd')
         inst = self._makeOne(f)
@@ -96,7 +97,7 @@ class TestFileBasedBuffer(unittest.TestCase):
         inst.prune()
         self.assertTrue(inst.file is not f)
         self.assertEqual(nf.getvalue(), b'd')
-        
+
     def test_prune_remain_zero_tell_zero(self):
         f = io.BytesIO()
         inst = self._makeOne(f)
@@ -111,6 +112,7 @@ class TestFileBasedBuffer(unittest.TestCase):
         self.assertTrue(f.closed)
 
 class TestTempfileBasedBuffer(unittest.TestCase):
+
     def _makeOne(self, from_buffer=None):
         from waitress.buffers import TempfileBasedBuffer
         return TempfileBasedBuffer(from_buffer=from_buffer)
@@ -121,6 +123,7 @@ class TestTempfileBasedBuffer(unittest.TestCase):
         self.assertTrue(hasattr(r, 'fileno')) # file
 
 class TestBytesIOBasedBuffer(unittest.TestCase):
+
     def _makeOne(self, from_buffer=None):
         from waitress.buffers import BytesIOBasedBuffer
         return BytesIOBasedBuffer(from_buffer=from_buffer)
@@ -141,6 +144,7 @@ class TestBytesIOBasedBuffer(unittest.TestCase):
         self.assertTrue(hasattr(r, 'read'))
 
 class TestReadOnlyFileBasedBuffer(unittest.TestCase):
+
     def _makeOne(self, file, block_size=8192):
         from waitress.buffers import ReadOnlyFileBasedBuffer
         return ReadOnlyFileBasedBuffer(file, block_size)
@@ -216,7 +220,7 @@ class TestReadOnlyFileBasedBuffer(unittest.TestCase):
         self.assertEqual(f.tell(), 1)
 
     def test___iter__(self):
-        data = b'a'*10000
+        data = b'a' * 10000
         f = io.BytesIO(data)
         inst = self._makeOne(f)
         r = b''
@@ -229,6 +233,7 @@ class TestReadOnlyFileBasedBuffer(unittest.TestCase):
         self.assertRaises(NotImplementedError, inst.append, 'a')
 
 class TestOverflowableBuffer(unittest.TestCase):
+
     def _makeOne(self, overflow=10):
         from waitress.buffers import OverflowableBuffer
         return OverflowableBuffer(overflow)
@@ -241,7 +246,7 @@ class TestOverflowableBuffer(unittest.TestCase):
         inst = self._makeOne()
         inst.buf = b'abc'
         self.assertEqual(len(inst), 3)
-        
+
     def test___nonzero__(self):
         inst = self._makeOne()
         inst.buf = b'abc'
@@ -255,7 +260,7 @@ class TestOverflowableBuffer(unittest.TestCase):
         class int_overflow_buf(bytes):
             def __len__(self):
                 # maxint + 1
-                return  0x7fffffffffffffff + 1
+                return 0x7fffffffffffffff + 1
         inst.buf = int_overflow_buf()
         self.assertEqual(bool(inst), True)
         inst.buf = b''
@@ -269,7 +274,7 @@ class TestOverflowableBuffer(unittest.TestCase):
         self.assertEqual(inst.buf.__class__, TempfileBasedBuffer)
         self.assertEqual(inst.buf.get(100), b'x' * 11)
         self.assertEqual(inst.strbuf, b'')
-        
+
     def test__create_buffer_small(self):
         from waitress.buffers import BytesIOBasedBuffer
         inst = self._makeOne()
@@ -284,21 +289,21 @@ class TestOverflowableBuffer(unittest.TestCase):
         inst.strbuf = b'x' * 5
         inst.append(b'hello')
         self.assertEqual(inst.strbuf, b'xxxxxhello')
-        
+
     def test_append_buf_None_longer_than_strbuf_limit(self):
         inst = self._makeOne(10000)
         inst.strbuf = b'x' * 8192
         inst.append(b'hello')
         self.assertEqual(inst.strbuf, b'')
         self.assertEqual(len(inst.buf), 8197)
-        
+
     def test_append_overflow(self):
         inst = self._makeOne(10)
         inst.strbuf = b'x' * 8192
         inst.append(b'hello')
         self.assertEqual(inst.strbuf, b'')
         self.assertEqual(len(inst.buf), 8197)
-        
+
     def test_append_sz_gt_overflow(self):
         from waitress.buffers import BytesIOBasedBuffer
         f = io.BytesIO(b'data')
@@ -310,13 +315,13 @@ class TestOverflowableBuffer(unittest.TestCase):
         self.assertEqual(f.getvalue(), b'data')
         self.assertTrue(inst.overflowed)
         self.assertNotEqual(inst.buf, buf)
-        
+
     def test_get_buf_None_skip_False(self):
         inst = self._makeOne()
         inst.strbuf = b'x' * 5
         r = inst.get(5)
         self.assertEqual(r, b'xxxxx')
-        
+
     def test_get_buf_None_skip_True(self):
         inst = self._makeOne()
         inst.strbuf = b'x' * 5
@@ -351,13 +356,16 @@ class TestOverflowableBuffer(unittest.TestCase):
         inst.buf = Buf()
         inst.prune()
         self.assertEqual(inst.buf.pruned, True)
-        
+
     def test_prune_with_buf_overflow(self):
         inst = self._makeOne()
         class DummyBuffer(io.BytesIO):
-            def getfile(self): return self
-            def prune(self): return True
-            def __len__(self): return 5
+            def getfile(self):
+                return self
+            def prune(self):
+                return True
+            def __len__(self):
+                return 5
         buf = DummyBuffer(b'data')
         inst.buf = buf
         inst.overflowed = True
@@ -369,7 +377,7 @@ class TestOverflowableBuffer(unittest.TestCase):
         inst = self._makeOne()
         f = inst.getfile()
         self.assertTrue(hasattr(f, 'read'))
-        
+
     def test_getfile_buf_not_None(self):
         inst = self._makeOne()
         buf = io.BytesIO()
@@ -392,8 +400,9 @@ class TestOverflowableBuffer(unittest.TestCase):
         inst.buf = buf
         inst._close()
         self.assertTrue(buf.closed)
-        
+
 class KindaFilelike(object):
+
     def __init__(self, bytes, close=None, tellresults=None):
         self.bytes = bytes
         self.tellresults = tellresults
@@ -401,11 +410,10 @@ class KindaFilelike(object):
             self.close = close
 
 class Filelike(KindaFilelike):
+
     def seek(self, v, whence=0):
         self.seeked = v
 
     def tell(self):
         v = self.tellresults.pop(0)
         return v
-    
-        

--- a/waitress/tests/test_channel.py
+++ b/waitress/tests/test_channel.py
@@ -2,6 +2,7 @@ import unittest
 import io
 
 class TestHTTPChannel(unittest.TestCase):
+
     def _makeOne(self, sock, addr, adj, map=None):
         from waitress.channel import HTTPChannel
         server = DummyServer()
@@ -37,7 +38,7 @@ class TestHTTPChannel(unittest.TestCase):
 
     def test_handle_write_not_connected(self):
         inst, sock, map = self._makeOneWithMap()
-        inst.connected  = False
+        inst.connected = False
         self.assertFalse(inst.handle_write())
 
     def test_handle_write_with_requests(self):
@@ -175,7 +176,8 @@ class TestHTTPChannel(unittest.TestCase):
         import socket
         inst, sock, map = self._makeOneWithMap()
         inst.will_close = False
-        def recv(b): raise socket.error
+        def recv(b):
+            raise socket.error
         inst.recv = recv
         inst.last_activity = 0
         inst.logger = DummyLogger()
@@ -246,7 +248,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.outbufs.append(buffer)
         inst.logger = DummyLogger()
         def doraise():
-            raise NotImplemented
+            raise NotImplementedError
         inst.outbufs[0]._close = doraise
         result = inst._flush_some()
         self.assertEqual(result, True)
@@ -543,36 +545,48 @@ class TestHTTPChannel(unittest.TestCase):
 class DummySock(object):
     blocking = False
     closed = False
+
     def __init__(self):
         self.sent = b''
+
     def setblocking(self, *arg):
         self.blocking = True
+
     def fileno(self):
         return 100
+
     def getpeername(self):
         return '127.0.0.1'
+
     def close(self):
         self.closed = True
+
     def send(self, data):
         self.sent += data
         return len(data)
 
 class DummyLock(object):
+
     def __init__(self, acquirable=True):
         self.acquirable = acquirable
+
     def acquire(self, val):
         self.val = val
         self.acquired = True
         return self.acquirable
+
     def release(self):
         self.released = True
+
     def __exit__(self, type, val, traceback):
         self.acquire(True)
+
     def __enter__(self):
         pass
 
 class DummyBuffer(object):
     closed = False
+
     def __init__(self, data, toraise=None):
         self.data = data
         self.toraise = toraise
@@ -609,11 +623,14 @@ class DummyAdjustments(object):
 class DummyServer(object):
     trigger_pulled = False
     adj = DummyAdjustments()
+
     def __init__(self):
         self.tasks = []
         self.active_channels = {}
+
     def add_task(self, task):
         self.tasks.append(task)
+
     def pull_trigger(self):
         self.trigger_pulled = True
 
@@ -627,6 +644,7 @@ class DummyParser(object):
     retval = None
     error = None
     connection_close = False
+
     def received(self, data):
         self.data = data
         if self.retval is not None:
@@ -638,14 +656,18 @@ class DummyRequest(object):
     path = '/'
     version = '1.0'
     closed = False
+
     def __init__(self):
         self.headers = {}
+
     def _close(self):
         self.closed = True
-    
+
 class DummyLogger(object):
+
     def __init__(self):
         self.exceptions = []
+
     def exception(self, msg):
         self.exceptions.append(msg)
 
@@ -671,5 +693,3 @@ class DummyTaskClass(object):
         self.request.serviced = True
         if self.toraise:
             raise self.toraise
-
-    

--- a/waitress/tests/test_compat.py
+++ b/waitress/tests/test_compat.py
@@ -3,6 +3,7 @@
 import unittest
 
 class Test_unquote_bytes_to_wsgi(unittest.TestCase):
+
     def _callFUT(self, v):
         from waitress.compat import unquote_bytes_to_wsgi
         return unquote_bytes_to_wsgi(v)
@@ -17,4 +18,3 @@ class Test_unquote_bytes_to_wsgi(unittest.TestCase):
         else: # pragma: no cover
             # sanity
             self.assertEqual(result, b'/a\xc5\x9b')
-        

--- a/waitress/tests/test_functional.py
+++ b/waitress/tests/test_functional.py
@@ -9,7 +9,7 @@ import unittest
 from waitress.compat import (
     httplib,
     tobytes
-    )
+)
 from waitress.tests.support import TEST_PORT, TEST_SOCKET_PATH
 
 dn = os.path.dirname
@@ -27,7 +27,6 @@ class SubprocessTests(object):
 
     def stop_subprocess(self):
         if self.proc.returncode is None:
-            #self.conn.close()
             self.proc.terminate()
         self.sock.close()
 
@@ -38,13 +37,13 @@ class SubprocessTests(object):
         self.assertEqual(v, tobytes(version))
 
     def create_socket(self):
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError # pragma: no cover
 
     def connect(self):
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError # pragma: no cover
 
     def make_http_connection(self):
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError # pragma: no cover
 
     def send_check_error(self, to_send):
         self.sock.send(to_send)
@@ -84,6 +83,7 @@ class UnixTests(SubprocessTests):
 
 class SleepyThreadTests(TcpTests, unittest.TestCase):
     # test that sleepy thread doesnt block other requests
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'sleepy.py')
         self.start_subprocess([self.exe, echo])
@@ -96,7 +96,7 @@ class SleepyThreadTests(TcpTests, unittest.TestCase):
         cmds = (
             [self.exe, getline, 'http://127.0.0.1:%s/sleepy' % TEST_PORT],
             [self.exe, getline, 'http://127.0.0.1:%s/' % TEST_PORT]
-            )
+        )
         r, w = os.pipe()
         procs = []
         for cmd in cmds:
@@ -106,7 +106,7 @@ class SleepyThreadTests(TcpTests, unittest.TestCase):
             if proc.returncode is not None: # pragma: no cover
                 proc.terminate()
         # the notsleepy response should always be first returned (it sleeps
-        # for 2 seconds, then returns; the notsleepy response should be 
+        # for 2 seconds, then returns; the notsleepy response should be
         # processed in the meantime)
         result = os.read(r, 10000)
         os.close(r)
@@ -114,6 +114,7 @@ class SleepyThreadTests(TcpTests, unittest.TestCase):
         self.assertEqual(result, b'notsleepy returnedsleepy returned')
 
 class EchoTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'echo.py')
         self.start_subprocess([self.exe, echo])
@@ -191,7 +192,7 @@ class EchoTests(object):
             "Content-Length: %d\n"
             "\n"
             "%s" % (len(data), data)
-            )
+        )
         self.connect()
         self.sock.send(s)
         fp = self.sock.makefile('rb', 0)
@@ -209,7 +210,7 @@ class EchoTests(object):
             "Content-Length: %d\n"
             "\n"
             "%s" % (len(body), body)
-            )
+        )
         self.connect()
         self.sock.send(s)
         fp = self.sock.makefile('rb', 0)
@@ -236,7 +237,7 @@ class EchoTests(object):
         header = tobytes(
             "GET / HTTP/1.1\n"
             "Transfer-Encoding: chunked\n\n"
-            )
+        )
         self.connect()
         self.sock.send(header)
         self.sock.send(b"0\r\n\r\n")
@@ -246,13 +247,13 @@ class EchoTests(object):
         self.assertEqual(response_body, b'')
 
     def test_chunking_request_with_content(self):
-        control_line = b"20;\r\n"  # 20 hex = 32 dec
+        control_line = b"20;\r\n" # 20 hex = 32 dec
         s = b'This string has 32 characters.\r\n'
         expected = s * 12
         header = tobytes(
             "GET / HTTP/1.1\n"
             "Transfer-Encoding: chunked\n\n"
-            )
+        )
         self.connect()
         self.sock.send(header)
         fp = self.sock.makefile('rb', 0)
@@ -265,7 +266,7 @@ class EchoTests(object):
         self.assertEqual(response_body, expected)
 
     def test_broken_chunked_encoding(self):
-        control_line = "20;\r\n"  # 20 hex = 32 dec
+        control_line = "20;\r\n" # 20 hex = 32 dec
         s = 'This string has 32 characters.\r\n'
         to_send = "GET / HTTP/1.1\nTransfer-Encoding: chunked\n\n"
         to_send += (control_line + s)
@@ -292,10 +293,10 @@ class EchoTests(object):
         data = "Default: Don't keep me alive"
         s = tobytes(
             "GET / HTTP/1.0\n"
-             "Content-Length: %d\n"
-             "\n"
-             "%s" % (len(data), data)
-             )
+            "Content-Length: %d\n"
+            "\n"
+            "%s" % (len(data), data)
+        )
         self.connect()
         self.sock.send(s)
         response = httplib.HTTPResponse(self.sock)
@@ -313,11 +314,11 @@ class EchoTests(object):
         data = "Keep me alive"
         s = tobytes(
             "GET / HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: %d\n"
-             "\n"
-             "%s" % (len(data), data)
-            )
+            "Connection: Keep-Alive\n"
+            "Content-Length: %d\n"
+            "\n"
+            "%s" % (len(data), data)
+        )
         self.connect()
         self.sock.send(s)
         response = httplib.HTTPResponse(self.sock)
@@ -333,9 +334,9 @@ class EchoTests(object):
         data = "Default: Keep me alive"
         s = tobytes(
             "GET / HTTP/1.1\n"
-             "Content-Length: %d\n"
-             "\n"
-             "%s" % (len(data), data))
+            "Content-Length: %d\n"
+            "\n"
+            "%s" % (len(data), data))
         self.connect()
         self.sock.send(s)
         response = httplib.HTTPResponse(self.sock)
@@ -348,11 +349,11 @@ class EchoTests(object):
         data = "Default: Keep me alive"
         s = tobytes(
             "GET / HTTP/1.1\n"
-             "Connection: keep-alive\n"
-             "Content-Length: %d\n"
-             "\n"
-             "%s" % (len(data), data)
-             )
+            "Connection: keep-alive\n"
+            "Content-Length: %d\n"
+            "\n"
+            "%s" % (len(data), data)
+        )
         self.connect()
         self.sock.send(s)
         response = httplib.HTTPResponse(self.sock)
@@ -365,11 +366,11 @@ class EchoTests(object):
         data = "Don't keep me alive"
         s = tobytes(
             "GET / HTTP/1.1\n"
-             "Connection: close\n"
-             "Content-Length: %d\n"
-             "\n"
-             "%s" % (len(data), data)
-             )
+            "Connection: close\n"
+            "Content-Length: %d\n"
+            "\n"
+            "%s" % (len(data), data)
+        )
         self.connect()
         self.sock.send(s)
         response = httplib.HTTPResponse(self.sock)
@@ -378,6 +379,7 @@ class EchoTests(object):
         self.assertEqual(response.getheader('connection'), 'close')
 
 class PipeliningTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'echo.py')
         self.start_subprocess([self.exe, echo])
@@ -416,6 +418,7 @@ class PipeliningTests(object):
             self.assertEqual(response_body, expect_body)
 
 class ExpectContinueTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'echo.py')
         self.start_subprocess([self.exe, echo])
@@ -428,12 +431,12 @@ class ExpectContinueTests(object):
         data = "I have expectations"
         to_send = tobytes(
             "GET / HTTP/1.1\n"
-             "Connection: close\n"
-             "Content-Length: %d\n"
-             "Expect: 100-continue\n"
-             "\n"
-             "%s" % (len(data), data)
-             )
+            "Connection: close\n"
+            "Content-Length: %d\n"
+            "Expect: 100-continue\n"
+            "\n"
+            "%s" % (len(data), data)
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -453,6 +456,7 @@ class ExpectContinueTests(object):
         self.assertEqual(response_body, tobytes(data))
 
 class BadContentLengthTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'badcl.py')
         self.start_subprocess([self.exe, echo])
@@ -465,10 +469,10 @@ class BadContentLengthTests(object):
         # for cl header
         to_send = tobytes(
             "GET /short_body HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -479,7 +483,7 @@ class BadContentLengthTests(object):
         response_body = fp.read(content_length)
         self.assertEqual(int(status), 200)
         self.assertNotEqual(content_length, len(response_body))
-        self.assertEqual(len(response_body), content_length-1)
+        self.assertEqual(len(response_body), content_length - 1)
         self.assertEqual(response_body, tobytes('abcdefghi'))
         # remote closed connection (despite keepalive header); not sure why
         # first send succeeds
@@ -491,10 +495,10 @@ class BadContentLengthTests(object):
         # for cl header
         to_send = tobytes(
             "GET /long_body HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -517,6 +521,7 @@ class BadContentLengthTests(object):
         self.assertEqual(int(status), 200)
 
 class NoContentLengthTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'nocl.py')
         self.start_subprocess([self.exe, echo])
@@ -600,7 +605,7 @@ class NoContentLengthTests(object):
         for chunk in chunks(body, 10):
             expected += tobytes(
                 '%s\r\n%s\r\n' % (str(hex(len(chunk))[2:].upper()), chunk)
-                )
+            )
         expected += b'0\r\n\r\n'
         self.assertEqual(response_body, expected)
         # connection is always closed at the end of a chunked response
@@ -641,7 +646,7 @@ class NoContentLengthTests(object):
         for chunk in (body[0], body[1:]):
             expected += tobytes(
                 '%s\r\n%s\r\n' % (str(hex(len(chunk))[2:].upper()), chunk)
-                )
+            )
         expected += b'0\r\n\r\n'
         self.assertEqual(response_body, expected)
         # connection is always closed at the end of a chunked response
@@ -649,6 +654,7 @@ class NoContentLengthTests(object):
         self.assertRaises(ConnectionClosed, read_http, fp)
 
 class WriteCallbackTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'writecb.py')
         self.start_subprocess([self.exe, echo])
@@ -661,10 +667,10 @@ class WriteCallbackTests(object):
         # for cl header
         to_send = tobytes(
             "GET /short_body HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -674,7 +680,7 @@ class WriteCallbackTests(object):
         cl = int(headers['content-length'])
         self.assertEqual(cl, 9)
         self.assertNotEqual(cl, len(response_body))
-        self.assertEqual(len(response_body), cl-1)
+        self.assertEqual(len(response_body), cl - 1)
         self.assertEqual(response_body, tobytes('abcdefgh'))
         # remote closed connection (despite keepalive header)
         self.send_check_error(to_send)
@@ -685,10 +691,10 @@ class WriteCallbackTests(object):
         # for cl header
         to_send = tobytes(
             "GET /long_body HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -708,10 +714,10 @@ class WriteCallbackTests(object):
         # cl header
         to_send = tobytes(
             "GET /equal_body HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -731,10 +737,10 @@ class WriteCallbackTests(object):
         # wtf happens when there's no content-length
         to_send = tobytes(
             "GET /no_content_length HTTP/1.0\n"
-             "Connection: Keep-Alive\n"
-             "Content-Length: 0\n"
-             "\n"
-             )
+            "Connection: Keep-Alive\n"
+            "Content-Length: 0\n"
+            "\n"
+        )
         self.connect()
         self.sock.send(to_send)
         fp = self.sock.makefile('rb', 0)
@@ -858,8 +864,8 @@ class TooLargeTests(object):
         self.assertEqual(cl, len(response_body))
         # second response is an error response
         line, headers, response_body = read_http(fp)
-        self.assertline(line, '431', 'Request Header Fields Too Large', 
-                             'HTTP/1.0')
+        self.assertline(line, '431', 'Request Header Fields Too Large',
+                        'HTTP/1.0')
         cl = int(headers['content-length'])
         self.assertEqual(cl, len(response_body))
         # connection has been closed
@@ -901,8 +907,8 @@ class TooLargeTests(object):
         # so entire body looks like the header of the subsequent request
         # second response is an error response
         line, headers, response_body = read_http(fp)
-        self.assertline(line, '431', 'Request Header Fields Too Large', 
-                             'HTTP/1.0')
+        self.assertline(line, '431', 'Request Header Fields Too Large',
+                        'HTTP/1.0')
         cl = int(headers['content-length'])
         self.assertEqual(cl, len(response_body))
         # connection has been closed
@@ -927,7 +933,7 @@ class TooLargeTests(object):
         self.assertRaises(ConnectionClosed, read_http, fp)
 
     def test_request_body_too_large_chunked_encoding(self):
-        control_line = "20;\r\n"  # 20 hex = 32 dec
+        control_line = "20;\r\n" # 20 hex = 32 dec
         s = 'This string has 32 characters.\r\n'
         to_send = "GET / HTTP/1.1\nTransfer-Encoding: chunked\n\n"
         repeat = control_line + s
@@ -948,13 +954,14 @@ class TooLargeTests(object):
         self.assertRaises(ConnectionClosed, read_http, fp)
 
 class InternalServerErrorTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'error.py')
         self.start_subprocess([self.exe, echo])
 
     def tearDown(self):
         self.stop_subprocess()
-    
+
     def test_before_start_response(self):
         to_send = "GET /before_start_response HTTP/1.1\n\n"
         to_send = tobytes(to_send)
@@ -1012,13 +1019,14 @@ class InternalServerErrorTests(object):
         self.assertRaises(ConnectionClosed, read_http, fp)
 
 class FileWrapperTests(object):
+
     def setUp(self):
         echo = os.path.join(here, 'fixtureapps', 'filewrapper.py')
         self.start_subprocess([self.exe, echo])
 
     def tearDown(self):
         self.stop_subprocess()
-    
+
     def test_filelike_http11(self):
         to_send = "GET /filelike HTTP/1.1\n\n"
         to_send = tobytes(to_send)
@@ -1157,7 +1165,7 @@ class FileWrapperTests(object):
         line, headers, response_body = read_http(fp)
         self.assertline(line, '200', 'OK', 'HTTP/1.1')
         cl = int(headers['content-length'])
-        self.assertEqual(cl, len(response_body)+10)
+        self.assertEqual(cl, len(response_body) + 10)
         ct = headers['content-type']
         self.assertEqual(ct, 'image/jpeg')
         self.assertTrue(b'\377\330\377' in response_body)
@@ -1249,13 +1257,11 @@ class TcpExpectContinueTests(ExpectContinueTests, TcpTests, unittest.TestCase):
     pass
 
 class TcpBadContentLengthTests(
-    BadContentLengthTests, TcpTests, unittest.TestCase
-    ):
+        BadContentLengthTests, TcpTests, unittest.TestCase):
     pass
 
 class TcpNoContentLengthTests(
-    NoContentLengthTests, TcpTests, unittest.TestCase
-    ):
+        NoContentLengthTests, TcpTests, unittest.TestCase):
     pass
 
 class TcpWriteCallbackTests(WriteCallbackTests, TcpTests, unittest.TestCase):
@@ -1265,8 +1271,7 @@ class TcpTooLargeTests(TooLargeTests, TcpTests, unittest.TestCase):
     pass
 
 class TcpInternalServerErrorTests(
-    InternalServerErrorTests, TcpTests, unittest.TestCase
-    ):
+        InternalServerErrorTests, TcpTests, unittest.TestCase):
     pass
 
 class TcpFileWrapperTests(FileWrapperTests, TcpTests, unittest.TestCase):
@@ -1281,31 +1286,26 @@ if not sys.platform.startswith('win'):
         pass
 
     class UnixExpectContinueTests(
-        ExpectContinueTests, UnixTests, unittest.TestCase
-        ):
+            ExpectContinueTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixBadContentLengthTests(
-        BadContentLengthTests, UnixTests, unittest.TestCase
-        ):
+            BadContentLengthTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixNoContentLengthTests(
-        NoContentLengthTests, UnixTests, unittest.TestCase
-        ):
+            NoContentLengthTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixWriteCallbackTests(
-        WriteCallbackTests, UnixTests, unittest.TestCase
-        ):
+            WriteCallbackTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixTooLargeTests(TooLargeTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixInternalServerErrorTests(
-        InternalServerErrorTests, UnixTests, unittest.TestCase
-        ):
+            InternalServerErrorTests, UnixTests, unittest.TestCase):
         pass
 
     class UnixFileWrapperTests(FileWrapperTests, UnixTests, unittest.TestCase):
@@ -1327,9 +1327,11 @@ def parse_headers(fp):
 class UnixHTTPConnection(httplib.HTTPConnection):
     """Patched version of HTTPConnection that uses Unix domain sockets.
     """
+
     def __init__(self, path):
         httplib.HTTPConnection.__init__(self, 'localhost')
         self.path = path
+
     def connect(self):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(self.path)
@@ -1348,7 +1350,7 @@ def read_http(fp): # pragma: no cover
         raise
     if not response_line:
         raise ConnectionClosed
-  
+
     header_lines = []
     while True:
         line = fp.readline()
@@ -1366,7 +1368,7 @@ def read_http(fp): # pragma: no cover
         value = value.decode('iso-8859-1')
         assert key not in headers, "%s header duplicated" % key
         headers[key] = value
-  
+
     if 'content-length' in headers:
         num = int(headers['content-length'])
         body = b''
@@ -1380,7 +1382,7 @@ def read_http(fp): # pragma: no cover
     else:
         # read until EOF
         body = fp.read()
-  
+
     return response_line, headers, body
 
 # stolen from gevent
@@ -1393,9 +1395,9 @@ def get_errno(exc): # pragma: no cover
     i.e. http://bugs.python.org/issue6471
     Maybe there are cases when errno is set, but it is not the first argument?
     """
-  
     try:
-        if exc.errno is not None: return exc.errno
+        if exc.errno is not None:
+            return exc.errno
     except AttributeError:
         pass
     try:
@@ -1407,4 +1409,4 @@ def chunks(l, n):
     """ Yield successive n-sized chunks from l.
     """
     for i in range(0, len(l), n):
-        yield l[i:i+n]
+        yield l[i:i + n]

--- a/waitress/tests/test_init.py
+++ b/waitress/tests/test_init.py
@@ -1,6 +1,7 @@
 import unittest
 
 class Test_serve(unittest.TestCase):
+
     def _callFUT(self, app, **kw):
         from waitress import serve
         return serve(app, **kw)
@@ -14,6 +15,7 @@ class Test_serve(unittest.TestCase):
         self.assertEqual(server.ran, True)
 
 class Test_serve_paste(unittest.TestCase):
+
     def _callFUT(self, app, **kw):
         from waitress import serve_paste
         return serve_paste(app, None, **kw)
@@ -25,19 +27,21 @@ class Test_serve_paste(unittest.TestCase):
         self.assertEqual(server.app, app)
         self.assertEqual(result, 0)
         self.assertEqual(server.ran, True)
-        
+
 class DummyServerFactory(object):
     ran = False
+
     def __call__(self, app, **kw):
         self.adj = DummyAdj(kw)
         self.app = app
         self.kw = kw
         return self
+
     def run(self):
         self.ran = True
-        
+
 class DummyAdj(object):
     verbose = False
+
     def __init__(self, kw):
         self.__dict__.update(kw)
-    

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -18,9 +18,10 @@ import unittest
 from waitress.compat import (
     text_,
     tobytes,
-    )
+)
 
 class TestHTTPRequestParser(unittest.TestCase):
+
     def setUp(self):
         from waitress.parser import HTTPRequestParser
         from waitress.adjustments import Adjustments
@@ -94,7 +95,7 @@ GET /foobar HTTP/8.4
 Content-Length: 10
 
 """
-        result =self.parser.received(data)
+        result = self.parser.received(data)
         self.assertEqual(result, 41)
         self.assertTrue(self.parser.completed)
         self.assertTrue(isinstance(self.parser.error, RequestEntityTooLarge))
@@ -106,7 +107,7 @@ Content-Length: 10
 GET /foobar HTTP/8.4
 X-Foo: 1
 """
-        result =self.parser.received(data)
+        result = self.parser.received(data)
         self.assertEqual(result, 30)
         self.assertTrue(self.parser.completed)
         self.assertTrue(isinstance(self.parser.error,
@@ -171,7 +172,7 @@ foo: bar"""
         self.parser.parse_header(data)
         self.assertEqual(self.parser.body_rcv.__class__.__name__,
                          'ChunkedReceiver')
-        
+
     def test_parse_header_11_expect_continue(self):
         data = b"GET /foobar HTTP/1.1\nexpect: 100-continue"
         self.parser.parse_header(data)
@@ -193,13 +194,14 @@ foo: bar"""
         self.parser._close() # doesn't raise
 
 class Test_split_uri(unittest.TestCase):
+
     def _callFUT(self, uri):
         from waitress.parser import split_uri
         (self.proxy_scheme,
          self.proxy_netloc,
          self.path,
          self.query, self.fragment) = split_uri(uri)
-    
+
     def test_split_uri_unquoting_unneeded(self):
         self._callFUT(b'http://localhost:8080/abc def')
         self.assertEqual(self.path, '/abc def')
@@ -230,10 +232,11 @@ class Test_split_uri(unittest.TestCase):
         self.assertEqual(self.proxy_netloc, 'localhost:8080')
 
 class Test_get_header_lines(unittest.TestCase):
+
     def _callFUT(self, data):
         from waitress.parser import get_header_lines
         return get_header_lines(data)
-    
+
     def test_get_header_lines(self):
         result = self._callFUT(b'slam\nslim')
         self.assertEqual(result, [b'slam', b'slim'])
@@ -249,6 +252,7 @@ class Test_get_header_lines(unittest.TestCase):
                           self._callFUT, b' Host: localhost\r\n\r\n')
 
 class Test_crack_first_line(unittest.TestCase):
+
     def _callFUT(self, line):
         from waitress.parser import crack_first_line
         return crack_first_line(line)
@@ -372,12 +376,13 @@ Hello.
         self.feed(data)
         self.assertTrue(self.parser.completed)
         self.assertEqual(self.parser.headers, {
-                'CONTENT_LENGTH': '7',
-                'X_FORWARDED_FOR':
-                    '10.11.12.13, unknown,127.0.0.1, 255.255.255.255',
-                })
+            'CONTENT_LENGTH': '7',
+            'X_FORWARDED_FOR':
+                '10.11.12.13, unknown,127.0.0.1, 255.255.255.255',
+        })
 
 class DummyBodyStream(object):
+
     def getfile(self):
         return self
 
@@ -386,4 +391,3 @@ class DummyBodyStream(object):
 
     def _close(self):
         self.closed = True
-        

--- a/waitress/tests/test_receiver.py
+++ b/waitress/tests/test_receiver.py
@@ -1,6 +1,7 @@
 import unittest
 
 class TestFixedStreamReceiver(unittest.TestCase):
+
     def _makeOne(self, buf, cl):
         from waitress.receiver import FixedStreamReceiver
         return FixedStreamReceiver(buf, cl)
@@ -42,6 +43,7 @@ class TestFixedStreamReceiver(unittest.TestCase):
         self.assertEqual(inst.getbuf(), buf)
 
 class TestChunkedReceiver(unittest.TestCase):
+
     def _makeOne(self, buf):
         from waitress.receiver import ChunkedReceiver
         return ChunkedReceiver(buf)
@@ -134,17 +136,19 @@ class TestChunkedReceiver(unittest.TestCase):
         buf = DummyBuffer()
         inst = self._makeOne(buf)
         self.assertEqual(inst.getfile(), buf)
-    
+
     def test_getbuf(self):
         buf = DummyBuffer()
         inst = self._makeOne(buf)
         self.assertEqual(inst.getbuf(), buf)
 
 class DummyBuffer(object):
+
     def __init__(self):
         self.data = []
+
     def append(self, s):
         self.data.append(s)
+
     def getfile(self):
         return self
-    

--- a/waitress/tests/test_regression.py
+++ b/waitress/tests/test_regression.py
@@ -16,7 +16,7 @@
 import doctest
 
 class FakeSocket: # pragma: no cover
-    data        = ''
+    data = ''
     setblocking = lambda *_: None
     close = lambda *_: None
 
@@ -35,7 +35,6 @@ class FakeSocket: # pragma: no cover
 
     def recv(self, data):
         return 'data'
-
 
 def zombies_test():
     """Regression test for HTTPChannel.maintenance method

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -4,8 +4,9 @@ import sys
 import unittest
 
 class TestWSGIServer(unittest.TestCase):
+
     def _makeOne(self, application, host='127.0.0.1', port=0,
-                 _dispatcher=None, adj=None, map=None, _start=True, 
+                 _dispatcher=None, adj=None, map=None, _start=True,
                  _sock=None, _server=None):
         from waitress.server import WSGIServer
         return WSGIServer(
@@ -16,7 +17,7 @@ class TestWSGIServer(unittest.TestCase):
             _dispatcher=_dispatcher,
             _start=_start,
             _sock=_sock)
-    
+
     def _makeOneWithMap(self, adj=None, _start=True, host='127.0.0.1',
                         port=0, app=None):
         sock = DummySock()
@@ -30,7 +31,7 @@ class TestWSGIServer(unittest.TestCase):
             _sock=sock,
             _dispatcher=task_dispatcher,
             _start=_start,
-            )
+        )
 
     def test_ctor_start_true(self):
         inst = self._makeOneWithMap(_start=True)
@@ -90,12 +91,12 @@ class TestWSGIServer(unittest.TestCase):
         inst = self._makeOneWithMap()
         inst.accepting = False
         self.assertFalse(inst.readable())
-        
+
     def test_readable_maplen_gt_connection_limit(self):
         inst = self._makeOneWithMap()
         inst.accepting = True
         inst.adj = DummyAdj
-        inst._map = {'a':1, 'b':2}
+        inst._map = {'a': 1, 'b': 2}
         self.assertFalse(inst.readable())
 
     def test_readable_maplen_lt_connection_limit(self):
@@ -128,7 +129,7 @@ class TestWSGIServer(unittest.TestCase):
     def test_writable(self):
         inst = self._makeOneWithMap()
         self.assertFalse(inst.writable())
-        
+
     def test_handle_read(self):
         inst = self._makeOneWithMap()
         self.assertEqual(inst.handle_read(), None)
@@ -145,12 +146,12 @@ class TestWSGIServer(unittest.TestCase):
         self.assertEqual(inst.socket.accepted, False)
 
     def test_handle_accept_other_socket_error(self):
-        import socket
         inst = self._makeOneWithMap()
         eaborted = socket.error(errno.ECONNABORTED)
         inst.socket = DummySock(toraise=eaborted)
         inst.adj = DummyAdj
-        def foo(): raise socket.error
+        def foo():
+            raise socket.error
         inst.accept = foo
         inst.logger = DummyLogger()
         inst.handle_accept()
@@ -171,6 +172,7 @@ class TestWSGIServer(unittest.TestCase):
 
     def test_maintenance(self):
         inst = self._makeOneWithMap()
+
         class DummyChannel(object):
             requests = []
         zombie = DummyChannel()
@@ -181,9 +183,10 @@ class TestWSGIServer(unittest.TestCase):
         self.assertEqual(zombie.will_close, True)
 
 if not sys.platform.startswith('win'):
-        
+
     class TestUnixWSGIServer(unittest.TestCase):
         unix_socket = '/tmp/waitress.test.sock'
+
         def _makeOne(self, _start=True, _sock=None):
             from waitress.server import WSGIServer
             return WSGIServer(
@@ -194,7 +197,7 @@ if not sys.platform.startswith('win'):
                 _dispatcher=DummyTaskDispatcher(),
                 unix_socket=self.unix_socket,
                 unix_socket_perms='600'
-                )
+            )
 
         def _makeDummy(self, *args, **kwargs):
             sock = DummySock(*args, **kwargs)
@@ -222,45 +225,58 @@ if not sys.platform.startswith('win'):
             self.assertEqual(client.opts, [])
             self.assertEqual(
                 L,
-                [(inst, client,  ('localhost', None), inst.adj)]
-                )
+                [(inst, client, ('localhost', None), inst.adj)]
+            )
 
 class DummySock(object):
     accepted = False
     blocking = False
     family = socket.AF_INET
+
     def __init__(self, toraise=None, acceptresult=(None, None)):
         self.toraise = toraise
         self.acceptresult = acceptresult
         self.bound = None
         self.opts = []
+
     def bind(self, addr):
         self.bound = addr
+
     def accept(self):
         if self.toraise:
             raise self.toraise
         self.accepted = True
         return self.acceptresult
+
     def setblocking(self, x):
         self.blocking = True
+
     def fileno(self):
         return 10
+
     def getpeername(self):
         return '127.0.0.1'
+
     def setsockopt(self, *arg):
         self.opts.append(arg)
+
     def getsockopt(self, *arg):
         return 1
+
     def listen(self, num):
         self.listened = num
+
     def getsockname(self):
         return self.bound
 
 class DummyTaskDispatcher(object):
+
     def __init__(self):
         self.tasks = []
+
     def add_task(self, task):
         self.tasks.append(task)
+
     def shutdown(self):
         self.was_shutdown = True
 
@@ -269,9 +285,11 @@ class DummyTask(object):
     start_response_called = False
     wrote_header = False
     status = '200 OK'
+
     def __init__(self):
         self.response_headers = {}
         self.written = ''
+
     def service(self): # pragma: no cover
         self.serviced = True
 
@@ -280,19 +298,22 @@ class DummyAdj:
     log_socket_errors = True
     socket_options = [('level', 'optname', 'value')]
     cleanup_interval = 900
-    channel_timeout= 300
-    
+    channel_timeout = 300
+
 class DummyAsyncore(object):
+
     def loop(self, timeout=None, map=None):
         raise SystemExit
-    
+
 class DummyTrigger(object):
+
     def pull_trigger(self):
         self.pulled = True
-        
+
 class DummyLogger(object):
+
     def __init__(self):
         self.logged = []
+
     def warning(self, msg, **kw):
         self.logged.append(msg)
-        

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -2,6 +2,7 @@ import unittest
 import io
 
 class TestThreadedTaskDispatcher(unittest.TestCase):
+
     def _makeOne(self):
         from waitress.task import ThreadedTaskDispatcher
         return ThreadedTaskDispatcher()
@@ -37,14 +38,14 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
     def test_set_thread_count_increase_with_existing(self):
         inst = self._makeOne()
         L = []
-        inst.threads = {0:1}
+        inst.threads = {0: 1}
         inst.start_new_thread = lambda *x: L.append(x)
         inst.set_thread_count(2)
         self.assertEqual(L, [(inst.handler_thread, (1,))])
 
     def test_set_thread_count_decrease(self):
         inst = self._makeOne()
-        inst.threads = {'a':1, 'b':2}
+        inst.threads = {'a': 1, 'b': 2}
         inst.set_thread_count(1)
         self.assertEqual(inst.queue.qsize(), 1)
         self.assertEqual(inst.queue.get(), None)
@@ -53,7 +54,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst = self._makeOne()
         L = []
         inst.start_new_thread = lambda *x: L.append(x)
-        inst.threads = {0:1}
+        inst.threads = {0: 1}
         inst.set_thread_count(1)
         self.assertEqual(L, [])
 
@@ -92,6 +93,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
                          False)
 
 class TestTask(unittest.TestCase):
+
     def _makeOne(self, channel=None, request=None):
         if channel is None:
             channel = DummyChannel()
@@ -204,7 +206,7 @@ class TestTask(unittest.TestCase):
         inst = self._makeOne()
         inst.request = DummyParser()
         inst.version = '1.0'
-        inst.response_headers = [('Server',  'abc')]
+        inst.response_headers = [('Server', 'abc')]
         result = inst.build_response_header()
         lines = filter_lines(result)
         self.assertEqual(len(lines), 5)
@@ -218,7 +220,7 @@ class TestTask(unittest.TestCase):
         inst = self._makeOne()
         inst.request = DummyParser()
         inst.version = '1.0'
-        inst.response_headers = [('Date',  'date')]
+        inst.response_headers = [('Date', 'date')]
         result = inst.build_response_header()
         lines = filter_lines(result)
         self.assertEqual(len(lines), 4)
@@ -311,6 +313,7 @@ class TestTask(unittest.TestCase):
         self.assertEqual(len(inst.logger.logged), 1)
 
 class TestWSGITask(unittest.TestCase):
+
     def _makeOne(self, channel=None, request=None):
         if channel is None:
             channel = DummyChannel()
@@ -472,7 +475,7 @@ class TestWSGITask(unittest.TestCase):
     def test_execute_app_returns_closeable(self):
         class closeable(list):
             def close(self):
-                self.closed  = True
+                self.closed = True
         foo = closeable([b'abc'])
         def app(environ, start_response):
             start_response('200 OK', [('Content-Length', '3')])
@@ -566,8 +569,11 @@ class TestWSGITask(unittest.TestCase):
         import sys
         inst = self._makeOne()
         request = DummyParser()
-        request.headers = {'CONTENT_TYPE':'abc', 'CONTENT_LENGTH':'10',
-                                'X_FOO':'BAR'}
+        request.headers = {
+            'CONTENT_TYPE': 'abc',
+            'CONTENT_LENGTH': '10',
+            'X_FOO': 'BAR',
+        }
         request.query = 'abc'
         inst.request = request
         environ = inst.get_environment()
@@ -593,6 +599,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(inst.environ, environ)
 
 class TestErrorTask(unittest.TestCase):
+
     def _makeOne(self, channel=None, request=None):
         if channel is None:
             channel = DummyChannel()
@@ -626,6 +633,7 @@ class DummyTask(object):
     serviced = False
     deferred = False
     cancelled = False
+
     def __init__(self, toraise=None):
         self.toraise = toraise
 
@@ -651,6 +659,7 @@ class DummyAdj(object):
 class DummyServer(object):
     server_name = 'localhost'
     effective_port = 80
+
     def __init__(self):
         self.adj = DummyAdj()
 
@@ -659,12 +668,14 @@ class DummyChannel(object):
     adj = DummyAdj()
     creation_time = 0
     addr = ['127.0.0.1']
+
     def __init__(self, server=None):
         if server is None:
             server = DummyServer()
         self.server = server
         self.written = b''
         self.otherdata = []
+
     def write_soon(self, data):
         if isinstance(data, bytes):
             self.written += data
@@ -680,8 +691,10 @@ class DummyParser(object):
     url_scheme = 'http'
     expect_continue = False
     headers_finished = False
+
     def __init__(self):
         self.headers = {}
+
     def get_body_stream(self):
         return 'stream'
 
@@ -689,10 +702,12 @@ def filter_lines(s):
     return list(filter(None, s.split(b'\r\n')))
 
 class DummyLogger(object):
+
     def __init__(self):
         self.logged = []
+
     def warning(self, msg):
         self.logged.append(msg)
+
     def exception(self, msg):
         self.logged.append(msg)
-

--- a/waitress/tests/test_trigger.py
+++ b/waitress/tests/test_trigger.py
@@ -5,6 +5,7 @@ import sys
 if not sys.platform.startswith("win"):
 
     class Test_trigger(unittest.TestCase):
+
         def _makeOne(self, map):
             from waitress.trigger import trigger
             return trigger(map)
@@ -44,7 +45,7 @@ if not sys.platform.startswith("win"):
             inst = self._makeOne(map)
             self.assertEqual(inst.close(), None)
             self.assertEqual(inst._closed, True)
-            
+
         def test_handle_close(self):
             map = {}
             inst = self._makeOne(map)
@@ -57,7 +58,7 @@ if not sys.platform.startswith("win"):
             self.assertEqual(inst.pull_trigger(), None)
             r = os.read(inst._fds[0], 1)
             self.assertEqual(r, b'x')
-        
+
         def test_pull_trigger_thunk(self):
             map = {}
             inst = self._makeOne(map)
@@ -71,14 +72,14 @@ if not sys.platform.startswith("win"):
             inst = self._makeOne(map)
             result = inst.handle_read()
             self.assertEqual(result, None)
-            
+
         def test_handle_read_no_socket_error(self):
             map = {}
             inst = self._makeOne(map)
             inst.pull_trigger()
             result = inst.handle_read()
             self.assertEqual(result, None)
-            
+
         def test_handle_read_thunk(self):
             map = {}
             inst = self._makeOne(map)
@@ -102,4 +103,3 @@ if not sys.platform.startswith("win"):
             self.assertEqual(result, None)
             self.assertEqual(len(L), 1)
             self.assertEqual(inst.thunks, [])
-        

--- a/waitress/tests/test_utilities.py
+++ b/waitress/tests/test_utilities.py
@@ -15,6 +15,7 @@
 import unittest
 
 class Test_parse_http_date(unittest.TestCase):
+
     def _callFUT(self, v):
         from waitress.utilities import parse_http_date
         return parse_http_date(v)
@@ -35,6 +36,7 @@ class Test_parse_http_date(unittest.TestCase):
         self.assertEqual(result, 0)
 
 class Test_build_http_date(unittest.TestCase):
+
     def test_rountdrip(self):
         from waitress.utilities import build_http_date, parse_http_date
         from time import time
@@ -42,6 +44,7 @@ class Test_build_http_date(unittest.TestCase):
         self.assertEqual(t, parse_http_date(build_http_date(t)))
 
 class Test_unpack_rfc850(unittest.TestCase):
+
     def _callFUT(self, val):
         from waitress.utilities import unpack_rfc850, rfc850_reg
         return unpack_rfc850(rfc850_reg.match(val.lower()))
@@ -52,6 +55,7 @@ class Test_unpack_rfc850(unittest.TestCase):
         self.assertEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
 
 class Test_unpack_rfc_822(unittest.TestCase):
+
     def _callFUT(self, val):
         from waitress.utilities import unpack_rfc822, rfc822_reg
         return unpack_rfc822(rfc822_reg.match(val.lower()))
@@ -62,13 +66,14 @@ class Test_unpack_rfc_822(unittest.TestCase):
         self.assertEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
 
 class Test_find_double_newline(unittest.TestCase):
+
     def _callFUT(self, val):
         from waitress.utilities import find_double_newline
         return find_double_newline(val)
 
     def test_empty(self):
         self.assertEqual(self._callFUT(b''), -1)
-        
+
     def test_one_linefeed(self):
         self.assertEqual(self._callFUT(b'\n'), -1)
 
@@ -85,6 +90,7 @@ class Test_find_double_newline(unittest.TestCase):
         self.assertEqual(self._callFUT(b'\n\n00\r\n\r\n'), 2)
 
 class Test_logging_dispatcher(unittest.TestCase):
+
     def _makeOne(self):
         from waitress.utilities import logging_dispatcher
         return logging_dispatcher(map={})
@@ -99,6 +105,7 @@ class Test_logging_dispatcher(unittest.TestCase):
         self.assertEqual(logger.message, 'message')
 
 class TestBadRequest(unittest.TestCase):
+
     def _makeOne(self):
         from waitress.utilities import BadRequest
         return BadRequest(1)
@@ -108,9 +115,7 @@ class TestBadRequest(unittest.TestCase):
         self.assertEqual(inst.body, 1)
 
 class DummyLogger(object):
+
     def log(self, severity, message):
         self.severity = severity
         self.message = message
-        
-        
-        

--- a/waitress/trigger.py
+++ b/waitress/trigger.py
@@ -52,7 +52,7 @@ from waitress.compat import thread
 class _triggerbase(object):
     """OS-independent base class for OS-dependent trigger class."""
 
-    kind = None  # subclass must set to "pipe" or "loopback"; used by repr
+    kind = None # subclass must set to "pipe" or "loopback"; used by repr
 
     def __init__(self):
         self._closed = False
@@ -86,7 +86,7 @@ class _triggerbase(object):
         if not self._closed:
             self._closed = True
             self.del_channel()
-            self._close()  # subclass does OS-specific stuff
+            self._close() # subclass does OS-specific stuff
 
     def pull_trigger(self, thunk=None):
         if thunk:
@@ -156,42 +156,42 @@ else: # pragma: no cover
             w.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
             count = 0
-            while 1:
-               count += 1
-               # Bind to a local port; for efficiency, let the OS pick
-               # a free port for us.
-               # Unfortunately, stress tests showed that we may not
-               # be able to connect to that port ("Address already in
-               # use") despite that the OS picked it.  This appears
-               # to be a race bug in the Windows socket implementation.
-               # So we loop until a connect() succeeds (almost always
-               # on the first try).  See the long thread at
-               # http://mail.zope.org/pipermail/zope/2005-July/160433.html
-               # for hideous details.
-               a = socket.socket()
-               a.bind(("127.0.0.1", 0))
-               connect_address = a.getsockname()  # assigned (host, port) pair
-               a.listen(1)
-               try:
-                   w.connect(connect_address)
-                   break    # success
-               except socket.error as detail:
-                   if detail[0] != errno.WSAEADDRINUSE:
-                       # "Address already in use" is the only error
-                       # I've seen on two WinXP Pro SP2 boxes, under
-                       # Pythons 2.3.5 and 2.4.1.
-                       raise
-                   # (10048, 'Address already in use')
-                   # assert count <= 2 # never triggered in Tim's tests
-                   if count >= 10:  # I've never seen it go above 2
-                       a.close()
-                       w.close()
-                       raise RuntimeError("Cannot bind trigger!")
-                   # Close `a` and try again.  Note:  I originally put a short
-                   # sleep() here, but it didn't appear to help or hurt.
-                   a.close()
+            while True:
+                count += 1
+                # Bind to a local port; for efficiency, let the OS pick
+                # a free port for us.
+                # Unfortunately, stress tests showed that we may not
+                # be able to connect to that port ("Address already in
+                # use") despite that the OS picked it.  This appears
+                # to be a race bug in the Windows socket implementation.
+                # So we loop until a connect() succeeds (almost always
+                # on the first try).  See the long thread at
+                # http://mail.zope.org/pipermail/zope/2005-July/160433.html
+                # for hideous details.
+                a = socket.socket()
+                a.bind(("127.0.0.1", 0))
+                connect_address = a.getsockname() # assigned (host, port) pair
+                a.listen(1)
+                try:
+                    w.connect(connect_address)
+                    break # success
+                except socket.error as detail:
+                    if detail[0] != errno.WSAEADDRINUSE:
+                        # "Address already in use" is the only error
+                        # I've seen on two WinXP Pro SP2 boxes, under
+                        # Pythons 2.3.5 and 2.4.1.
+                        raise
+                    # (10048, 'Address already in use')
+                    # assert count <= 2 # never triggered in Tim's tests
+                    if count >= 10: # I've never seen it go above 2
+                        a.close()
+                        w.close()
+                        raise RuntimeError("Cannot bind trigger!")
+                    # Close `a` and try again.  Note:  I originally put a short
+                    # sleep() here, but it didn't appear to help or hurt.
+                    a.close()
 
-            r, addr = a.accept()  # r becomes asyncore's (self.)socket
+            r, addr = a.accept() # r becomes asyncore's (self.)socket
             a.close()
             self.trigger = w
             asyncore.dispatcher.__init__(self, r, map=map)

--- a/waitress/utilities.py
+++ b/waitress/utilities.py
@@ -27,10 +27,10 @@ logger = logging.getLogger('waitress')
 
 def find_double_newline(s):
     """Returns the position just after a double newline in the given string."""
-    pos1 = s.find(b'\n\r\n')  # One kind of double newline
+    pos1 = s.find(b'\n\r\n') # One kind of double newline
     if pos1 >= 0:
         pos1 += 3
-    pos2 = s.find(b'\n\n')    # Another kind of double newline
+    pos2 = s.find(b'\n\n')   # Another kind of double newline
     if pos2 >= 0:
         pos2 += 2
 
@@ -51,9 +51,9 @@ def join(seq, field=' '):
 def group(s):
     return '(' + s + ')'
 
-short_days = ['sun','mon','tue','wed','thu','fri','sat']
-long_days = ['sunday','monday','tuesday','wednesday',
-             'thursday','friday','saturday']
+short_days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
+long_days = ['sunday', 'monday', 'tuesday', 'wednesday',
+             'thursday', 'friday', 'saturday']
 
 short_day_reg = group(join(short_days, '|'))
 long_day_reg = group(join(long_days, '|'))
@@ -65,12 +65,12 @@ for i in range(7):
 
 hms_reg = join(3 * [group('[0-9][0-9]')], ':')
 
-months = ['jan','feb','mar','apr','may','jun','jul',
-          'aug','sep','oct','nov','dec']
+months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul',
+          'aug', 'sep', 'oct', 'nov', 'dec']
 
 monmap = {}
 for i in range(12):
-    monmap[months[i]] = i+1
+    monmap[months[i]] = i + 1
 
 months_reg = group(join(months, '|'))
 
@@ -81,47 +81,47 @@ months_reg = group(join(months, '|'))
 
 # rfc822 format
 rfc822_date = join(
-        [concat (short_day_reg,','),            # day
-         group('[0-9][0-9]?'),                  # date
-         months_reg,                            # month
-         group('[0-9]+'),                       # year
-         hms_reg,                               # hour minute second
-         'gmt'
-         ],
-        ' '
-        )
+    [concat(short_day_reg, ','),            # day
+     group('[0-9][0-9]?'),                  # date
+     months_reg,                            # month
+     group('[0-9]+'),                       # year
+     hms_reg,                               # hour minute second
+     'gmt'
+     ],
+    ' '
+)
 
 rfc822_reg = re.compile(rfc822_date)
 
 def unpack_rfc822(m):
     g = m.group
     return (
-            int(g(4)),             # year
-            monmap[g(3)],        # month
-            int(g(2)),             # day
-            int(g(5)),             # hour
-            int(g(6)),             # minute
-            int(g(7)),             # second
-            0,
-            0,
-            0
-            )
+        int(g(4)),             # year
+        monmap[g(3)],          # month
+        int(g(2)),             # day
+        int(g(5)),             # hour
+        int(g(6)),             # minute
+        int(g(7)),             # second
+        0,
+        0,
+        0,
+    )
 
-    # rfc850 format
+# rfc850 format
 rfc850_date = join(
-        [concat(long_day_reg,','),
-         join(
-                 [group ('[0-9][0-9]?'),
-                  months_reg,
-                  group ('[0-9]+')
-                  ],
-                 '-'
-                 ),
-         hms_reg,
-         'gmt'
-         ],
-        ' '
-        )
+    [concat(long_day_reg, ','),
+     join(
+         [group('[0-9][0-9]?'),
+          months_reg,
+          group('[0-9]+')
+          ],
+         '-'
+     ),
+     hms_reg,
+     'gmt'
+     ],
+    ' '
+)
 
 rfc850_reg = re.compile(rfc850_date)
 # they actually unpack the same way
@@ -129,21 +129,21 @@ def unpack_rfc850(m):
     g = m.group
     yr = g(4)
     if len(yr) == 2:
-        yr = '19'+yr
+        yr = '19' + yr
     return (
-            int(yr),           # year
-            monmap[g(3)],        # month
-            int(g(2)),           # day
-            int(g(5)),           # hour
-            int(g(6)),           # minute
-            int(g(7)),           # second
-            0,
-            0,
-            0
-            )
+        int(yr),             # year
+        monmap[g(3)],        # month
+        int(g(2)),           # day
+        int(g(5)),           # hour
+        int(g(6)),           # minute
+        int(g(7)),           # second
+        0,
+        0,
+        0
+    )
 
-    # parsdate.parsedate        - ~700/sec.
-    # parse_http_date            - ~1333/sec.
+# parsdate.parsedate - ~700/sec.
+# parse_http_date    - ~1333/sec.
 
 weekdayname = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 monthname = [None, 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -152,9 +152,9 @@ monthname = [None, 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 def build_http_date(when):
     year, month, day, hh, mm, ss, wd, y, z = time.gmtime(when)
     return "%s, %02d %3s %4d %02d:%02d:%02d GMT" % (
-            weekdayname[wd],
-            day, monthname[month], year,
-            hh, mm, ss)
+        weekdayname[wd],
+        day, monthname[month], year,
+        hh, mm, ss)
 
 def parse_http_date(d):
     d = d.lower()
@@ -171,12 +171,13 @@ def parse_http_date(d):
 
 class logging_dispatcher(asyncore.dispatcher):
     logger = logger
+
     def log_info(self, message, type='info'):
         severity = {
             'info': logging.INFO,
             'warning': logging.WARN,
             'error': logging.ERROR,
-            }
+        }
         self.logger.log(severity.get(type, logging.INFO), message)
 
 def cleanup_unix_socket(path):
@@ -184,12 +185,13 @@ def cleanup_unix_socket(path):
         st = os.stat(path)
     except OSError as exc:
         if exc.errno != errno.ENOENT:
-            raise  # pragma: no cover
+            raise # pragma: no cover
     else:
         if stat.S_ISSOCK(st.st_mode):
             os.remove(path)
 
 class Error(object):
+
     def __init__(self, body):
         self.body = body
 
@@ -208,5 +210,3 @@ class RequestEntityTooLarge(BadRequest):
 class InternalServerError(Error):
     code = 500
     reason = 'Internal Server Error'
-        
-    


### PR DESCRIPTION
In the interests of avoiding accidentally including janitorial changes in any possible future pull requests. I figured I'd might as well run waitress through autopep8. After reverting some of its more overly-enthusiastic changes and fixing a few other issues I noticed, here's the result.

In addition, this pull request includes the following fixes:
- outbuf_overflow was documented with the incorrect default value.
- In TestHTTPChannel, 'NotImplemented' was being raised as an exception instead of 'NotImplementedError', which appeared to be a typo.
- A number of lists in waitress.utilities are now tuples.
