### PR TITLE
Pre-0.8.4 compatibility.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+Next Release
+------------
+
+- For compatibility, WSGIServer is now an alias of TcpWSGIServer. The
+  signature of BaseWSGIServer is now compatible with WSGIServer pre-0.8.4.
+
 0.8.4 (2013-05-24)
 ------------------
 

--- a/waitress/__init__.py
+++ b/waitress/__init__.py
@@ -1,8 +1,8 @@
-from waitress.server import WSGIServer
+from waitress.server import WSGIServer, create_server
 import logging
 
 def serve(app, **kw):
-    _server = kw.pop('_server', WSGIServer) # test shim
+    _server = kw.pop('_server', create_server) # test shim
     _quiet = kw.pop('_quiet', False) # test shim
     _profile = kw.pop('_profile', False) # test shim
     if not _quiet: # pragma: no cover

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -24,16 +24,16 @@ from waitress.channel import HTTPChannel
 from waitress.task import ThreadedTaskDispatcher
 from waitress.utilities import cleanup_unix_socket, logging_dispatcher
 
-def WSGIServer(application,
-               map=None,
-               _start=True,      # test shim
-               _sock=None,       # test shim
-               _dispatcher=None, # test shim
-               **kw              # adjustments
-               ):
+def create_server(application,
+                  map=None,
+                  _start=True,      # test shim
+                  _sock=None,       # test shim
+                  _dispatcher=None, # test shim
+                  **kw              # adjustments
+                  ):
     """
     if __name__ == '__main__':
-        server = WSGIServer(app)
+        server = create_server(app)
         server.run()
     """
     adj = Adjustments(**kw)
@@ -53,13 +53,15 @@ class BaseWSGIServer(logging_dispatcher, object):
 
     def __init__(self,
                  application,
-                 map,
-                 _start,      # test shim
-                 _sock,       # test shim
-                 _dispatcher, # test shim
-                 adj          # adjustments
+                 map=None,
+                 _start=True,      # test shim
+                 _sock=None,       # test shim
+                 _dispatcher=None, # test shim
+                 adj=None,         # adjustments
+                 **kw
                  ):
-
+        if adj is None:
+            adj = Adjustments(**kw)
         self.application = application
         self.adj = adj
         self.trigger = trigger.trigger(map)
@@ -206,3 +208,6 @@ class UnixWSGIServer(BaseWSGIServer):
 
     def fix_addr(self, addr):
         return ('localhost', None)
+
+# Compatibility alias.
+WSGIServer = TcpWSGIServer

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -8,8 +8,8 @@ class TestWSGIServer(unittest.TestCase):
     def _makeOne(self, application, host='127.0.0.1', port=0,
                  _dispatcher=None, adj=None, map=None, _start=True,
                  _sock=None, _server=None):
-        from waitress.server import WSGIServer
-        return WSGIServer(
+        from waitress.server import create_server
+        return create_server(
             application,
             host=host,
             port=port,
@@ -182,14 +182,23 @@ class TestWSGIServer(unittest.TestCase):
         inst.maintenance(10000)
         self.assertEqual(zombie.will_close, True)
 
+    def test_backward_compatibility(self):
+        from waitress.server import WSGIServer, TcpWSGIServer
+        from waitress.adjustments import Adjustments
+        self.assertTrue(WSGIServer is TcpWSGIServer)
+        inst = WSGIServer(None, _start=False, port=1234)
+        # Ensure the adjustment was actually applied.
+        self.assertNotEqual(Adjustments.port, 1234)
+        self.assertEqual(inst.adj.port, 1234)
+
 if not sys.platform.startswith('win'):
 
     class TestUnixWSGIServer(unittest.TestCase):
         unix_socket = '/tmp/waitress.test.sock'
 
         def _makeOne(self, _start=True, _sock=None):
-            from waitress.server import WSGIServer
-            return WSGIServer(
+            from waitress.server import create_server
+            return create_server(
                 None,
                 map={},
                 _start=_start,


### PR DESCRIPTION
0.8.4 introduced an incompatibility with WebTest as WebTest subclasses
WSGIServer as webtest.http.StopableWSGIServer. This commit introduces
changes to make WSGIServer subclassable once more by making the
signature of BaseWSGIServer's `__init__` method compatible with the
pre-0.8.4 WSGIServer class, and by making WSGIServer an alias of
TcpWSGIServer.

This method was suggested and chosen from a discussion with Laurence
Rowe (@lrowe).
