### PR TITLE
Nits.

### DIFF
--- a/waitress/runner.py
+++ b/waitress/runner.py
@@ -117,8 +117,8 @@ Tuning options:
         The timeout value in seconds passed to asyncore.loop(). Default is 1.
 
     --asyncore-use-poll
-        The use_poll argument passed to ``asyncore.loop()``. Helps overcome open
-        file descriptors limit. Default is False.
+        The use_poll argument passed to ``asyncore.loop()``. Helps overcome
+        open file descriptors limit. Default is False.
 
 """
 
@@ -158,7 +158,7 @@ def resolve(module_name, object_name):
         obj = getattr(obj, segment)
     return obj
 
-def show_help(stream, name, error=None):  # pragma: no cover
+def show_help(stream, name, error=None): # pragma: no cover
     if error is not None:
         print('Error: {0}\n'.format(error), file=stream)
     print(HELP.format(name), file=stream)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -461,7 +461,7 @@ class WSGITask(Task):
             mykey = rename_headers.get(key, None)
             if mykey is None:
                 mykey = 'HTTP_%s' % key
-            if not mykey in environ:
+            if mykey not in environ:
                 environ[mykey] = value
 
         # the following environment variables are required by the WSGI spec

--- a/waitress/tests/test_functional.py
+++ b/waitress/tests/test_functional.py
@@ -211,7 +211,7 @@ class EchoTests(object):
         fp = self.sock.makefile('rb', 0)
         line, headers, response_body = read_http(fp)
         self.assertline(line, '200', 'OK', 'HTTP/1.0')
-        headers['content-length']
+        self.assertEqual(int(headers['content-length']), len(data))
         self.assertEqual(len(response_body), len(data))
         self.assertEqual(response_body, tobytes(data))
 


### PR DESCRIPTION
- Wrap help text to 80 characters.
- Remove stray double space before '#'.
- Add missing assertion.
- Change 'not foo in bar' to 'foo not in bar' for consistency.
