### PR TITLE
Waitress needs clear error message on no WSGI app

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -389,6 +389,10 @@ class WSGITask(Task):
             return self.write
 
         # Call the application to handle the request and write a response
+        if self.channel.server.application is None:
+            raise Exception("Cannot process request (WSGI application missing). "
+                            "Was None pass where WSGI application was expected?")
+
         app_iter = self.channel.server.application(env, start_response)
 
         try:


### PR DESCRIPTION
If a WSGI application was not passed to waitress, no errors are raised during server start up and only a confusing error message in the output (and nothing useful in the HTTP response). This request improves the error message in the log.

While this may seem unnecessary, it is a very easy beginner mistake to use this **init**.py code in your Pyramid app:

```
#BAD!
def main(global_config, **settings):
    """ This function returns a Pyramid WSGI application."""
    config = Configurator(settings=settings)
    dependencies.configure(config)
    routing.configure(config)
    config.make_wsgi_app() # YIKES forgot return keyword 
```

The result of running the site with the missing return value is an error basically like this:

```
pserve /site/development.ini
Starting server in PID 7817.
serving on http://0.0.0.0:6543
2014-05-04 16:45:51,285 ERROR [waitress][Dummy-1] Exception when serving /
Traceback (most recent call last):
  File "/Users/mkennedy/programming/github/waitress/waitress/channel.py", line 337, in service
    task.service()
  File "/Users/mkennedy/programming/github/waitress/waitress/task.py", line 173, in service
    self.execute()
  File "/Users/mkennedy/programming/github/waitress/waitress/task.py", line 396, in execute
    app_iter = self.channel.server.application(env, start_response)
TypeError: 'NoneType' object is not callable
```

That is entirely non-debuggable and non-googlable. With my proposed change, you'll see:

```
...
  File "/Users/mkennedy/programming/github/waitress/waitress/task.py", line 393, in execute
    raise Exception("Cannot process request (WSGI application missing). "
Exception: Cannot process request (WSGI application missing). Was None pass where WSGI application was expected?
```

I think this is much more helpful.

I originally tried to verify this on server start rather than first request. But so many of the unit tests pass None for app that I decided it wasn't worth the trouble.
