### PR TITLE
IPv6 support

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -125,3 +125,8 @@ url_prefix
     to be the value passed minus any trailing slashes you add, and it will
     cause the ``PATH_INFO`` of any request which is prefixed with this value to
     be stripped of the prefix.  Default: the empty string.
+
+ipv6
+    Boolean: allow IPv6 network connections (address family AF_INET6). To bind
+    to all IPv6 and IPv4 addresses on this host, set ``host`` to ``::``.
+    Default: ``False``.

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -72,6 +72,7 @@ class Adjustments(object):
         ('asyncore_use_poll', asbool),
         ('unix_socket', str),
         ('unix_socket_perms', asoctal),
+        ('ipv6', asbool),
     )
 
     _param_map = dict(_params)
@@ -173,6 +174,9 @@ class Adjustments(object):
 
     # The asyncore.loop flag to use poll() instead of the default select().
     asyncore_use_poll = False
+
+    # Allow IPv6 addresses? If true, use host :: to bind to all addresses (similar to 0.0.0.0)
+    ipv6 = False
 
     def __init__(self, **kw):
         for k, v in kw.items():

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -64,6 +64,9 @@ class BaseWSGIServer(logging_dispatcher, object):
             adj = Adjustments(**kw)
         self.application = application
         self.adj = adj
+        if self.adj.ipv6:
+            # If host is "0.0.0.0", maybe we should set it to "::" instead?
+            self.family = socket.AF_INET6
         self.trigger = trigger.trigger(map)
         if _dispatcher is None:
             _dispatcher = ThreadedTaskDispatcher()
@@ -74,7 +77,9 @@ class BaseWSGIServer(logging_dispatcher, object):
             self.create_socket(self.family, socket.SOCK_STREAM)
         self.set_reuse_addr()
         self.bind_server_socket()
-        self.effective_host, self.effective_port = self.getsockname()
+
+        # IPv6 additional parameters ignored: flowinfo, scopeid
+        self.effective_host, self.effective_port = self.getsockname()[:2]
         self.server_name = self.get_server_name(self.adj.host)
         self.active_channels = {}
         if _start:


### PR DESCRIPTION
Hey, this seems to enable IPv6 support in my limited testing. I have not added a unit test for IPv6 though.

To enable listening on all IPv4 and IPv6 addresses on that host, give these options to waitress:
```
ipv6=True
host="::"
```