### PR TITLE
Prevent header spoofing via underscore/dash conflation.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -120,3 +120,5 @@ Contributors
 - Jamie Matthews, 2013/06/19
 
 - Adam Groszer, 2013/08/15
+
+- Matt Russell, 2015/01/14

--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -182,6 +182,8 @@ class HTTPRequestParser(object):
             index = line.find(b':')
             if index > 0:
                 key = line[:index]
+                if '_' in key:
+                    continue
                 value = line[index + 1:].strip()
                 key1 = tostr(key.upper().replace(b'-', b'_'))
                 # If a header already exists, we append subsequent values

--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -182,7 +182,7 @@ class HTTPRequestParser(object):
             index = line.find(b':')
             if index > 0:
                 key = line[:index]
-                if '_' in key:
+                if b'_' in key:
                     continue
                 value = line[index + 1:].strip()
                 key1 = tostr(key.upper().replace(b'-', b'_'))

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -396,8 +396,23 @@ Hello.
         self.assertEqual(self.parser.headers, {
             'CONTENT_LENGTH': '7',
             'X_FORWARDED_FOR':
-                '10.11.12.13, unknown,127.0.0.1, 255.255.255.255',
+                '10.11.12.13, unknown,127.0.0.1',
         })
+
+    def testSpoofedHeadersDropped(self):
+        data = b"""\
+GET /foobar HTTP/8.4
+x-auth_user: bob
+content-length: 7
+
+Hello.
+"""
+        self.feed(data)
+        self.assertTrue(self.parser.completed)
+        self.assertEqual(self.parser.headers, {
+            'CONTENT_LENGTH': '7',
+        })
+
 
 class DummyBodyStream(object):
 


### PR DESCRIPTION
This PR prevents the WSGI header attack as documented here (by dropped headers containing underscores from the request) 
See https://www.djangoproject.com/weblog/2015/jan/13/security/
