### PR TITLE
Fix FileBasedBuffer (and ReadOnlyFileBasedBuffer) to act more like iterators

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Next release
 ------------
 
+- FileBasedBuffer and more important ReadOnlyFileBasedBuffer no longer report
+  False when tested with bool(), instead always returning True, and becoming
+  more iterator like.
+  See: https://github.com/Pylons/waitress/pull/82 and
+  https://github.com/Pylons/waitress/issues/76
+
 - Call prune() on the output buffer at the end of a request so that it doesn't
   continue to grow without bounds. See
   https://github.com/Pylons/waitress/issues/111 for more information.

--- a/waitress/buffers.py
+++ b/waitress/buffers.py
@@ -44,7 +44,7 @@ class FileBasedBuffer(object):
         return self.remain
 
     def __nonzero__(self):
-        return self.remain > 0
+        return True
 
     __bool__ = __nonzero__ # py3
 

--- a/waitress/tests/test_buffers.py
+++ b/waitress/tests/test_buffers.py
@@ -31,7 +31,7 @@ class TestFileBasedBuffer(unittest.TestCase):
         inst.remain = 10
         self.assertEqual(bool(inst), True)
         inst.remain = 0
-        self.assertEqual(bool(inst), False)
+        self.assertEqual(bool(inst), True)
 
     def test_append(self):
         f = io.BytesIO(b'data')


### PR DESCRIPTION
FileBasedBuffer is the parent class for a variety of sub-classes,
including ReadOnlyFileBasedBuffer. Since FileBasedBuffer can be used as
an app_iter return (and by extension it's sub-classes can as well) it
should probably behave more like an iterator, and the file returned from
open().

Even if an iterator contains no more objects, calling bool() will still
return True, in the case of FileBasedBuffer this is not true until this
fix.

----

Without this fix, if an application calls a second WSGI application that
returns an wsgi.file_wrapper (aka ReadOnlyFileBasedBuffer) they can't
simply test to see if the application returned a valid iterator or not
by testing it's truthiness.

This is documented in bug report: #76 

While one could argue that testing the truthiness of a return from an
WSGI application is the wrong thing to do, I would argue that an
iterator like object should not return False when tested with bool.
bool(iter([])) == True after all.

Fixes: #76 