### PR TITLE
pep440 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.version_info[:2] == (2, 6):
 
 setup(
     name='waitress',
-    version='0.8.10dev',
+    version='0.8.10dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     maintainer="Chris McDonough",


### PR DESCRIPTION
The current version doesn't match pep440 and causes `tox` to fail after the initial creation of the environments, so you have to run tox with `-r`, thereby reinstalling all dependencies each time.