### PR TITLE
Fix multi line header parsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,7 +23,8 @@ Next release
   occuring during runtime.  See https://github.com/Pylons/waitress/pull/60
 
 - Fix parsing of multi-line (folded) headers.
-  See https://github.com/Pylons/waitress/issues/53
+  See https://github.com/Pylons/waitress/issues/53 and
+  https://github.com/Pylons/waitress/pull/90
 
 0.8.9 (2014-05-16)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@ Next release
   constructor function, a ValueError is now raised eagerly instead of an error
   occuring during runtime.  See https://github.com/Pylons/waitress/pull/60
 
+- Fix parsing of multi-line (folded) headers.
+  See https://github.com/Pylons/waitress/issues/53
+
 0.8.9 (2014-05-16)
 ------------------
 

--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -271,7 +271,7 @@ def get_header_lines(header):
             if not r:
                 # http://corte.si/posts/code/pathod/pythonservers/index.html
                 raise ParsingError('Malformed header line "%s"' % tostr(line))
-            r[-1] = r[-1] + line[1:]
+            r[-1] += line
         else:
             r.append(line)
     return r

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -259,9 +259,21 @@ class Test_get_header_lines(unittest.TestCase):
         result = self._callFUT(b'slam\nslim')
         self.assertEqual(result, [b'slam', b'slim'])
 
+    def test_get_header_lines_folded(self):
+        # From RFC2616:
+        # HTTP/1.1 header field values can be folded onto multiple lines if the
+        # continuation line begins with a space or horizontal tab. All linear
+        # white space, including folding, has the same semantics as SP. A
+        # recipient MAY replace any linear white space with a single SP before
+        # interpreting the field value or forwarding the message downstream.
+
+        # We are just preserving the whitespace that indicates folding.
+        result = self._callFUT(b'slim\n slam')
+        self.assertEqual(result, [b'slim slam'])
+
     def test_get_header_lines_tabbed(self):
         result = self._callFUT(b'slam\n\tslim')
-        self.assertEqual(result, [b'slamslim'])
+        self.assertEqual(result, [b'slam\tslim'])
 
     def test_get_header_lines_malformed(self):
         # http://corte.si/posts/code/pathod/pythonservers/index.html


### PR DESCRIPTION
This fixes #53 by preserving the whitespace that indicates folded headers.