### PR TITLE
Switch from the low level Python thread/_thread module to the threading module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,9 @@ Next release
   See https://github.com/Pylons/waitress/issues/53 and
   https://github.com/Pylons/waitress/pull/90
 
+- Switch from the low level Python thread/_thread module to the threading
+  module.
+
 0.8.9 (2014-05-16)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -122,3 +122,5 @@ Contributors
 - Adam Groszer, 2013/08/15
 
 - David Glick, 2015/04/13
+
+- Shane Hathaway, 2015-04-20

--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -65,11 +65,6 @@ except ImportError: # pragma: no cover
         Empty,
     )
 
-try:
-    import thread
-except ImportError: # pragma: no cover
-    import _thread as thread
-
 if PY3: # pragma: no cover
     import builtins
     exec_ = getattr(builtins, "exec")


### PR DESCRIPTION
The high level threading module is the way forward for Python 3.  It also provides facilities like threading.settrace() that are not available in the low level module.