### PR TITLE
Add exception info

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,8 @@ Next release
 - Switch from the low level Python thread/_thread module to the threading
   module.
 
+- Improved exception information should module import go awry.
+
 0.8.9 (2014-05-16)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,3 +126,5 @@ Contributors
 - Shane Hathaway, 2015-04-20
 
 - Steve Piercy, 2015-04-21
+
+- Ben Warren, 2015-05-17

--- a/waitress/runner.py
+++ b/waitress/runner.py
@@ -171,17 +171,23 @@ def show_help(stream, name, error=None): # pragma: no cover
         print('Error: {0}\n'.format(error), file=stream)
     print(HELP.format(name), file=stream)
 
-
-def show_exception(stream): # pragma: no cover
-    exc_type, exc_value, exc_traceback = sys.exc_info()
+def show_exception(stream):
+    exc_type, exc_value = sys.exc_info()[:2]
+    args = getattr(exc_value, 'args', None)
     print(
-        'There was an exception ({0}) getting your module: "{1}" \n'.format(
-            exc_type,
-            exc_value
+        (
+            'There was an exception ({0}) importing your module.\n'
+        ).format(
+            exc_type.__name__,
         ),
         file=stream
     )
-
+    if args:
+        print('It had these arguments: ', file=stream)
+        for idx, arg in enumerate(args, start=1):
+            print('{0}. {1}\n'.format(idx, arg), file=stream)
+    else:
+        print('It had no arguments.', file=stream)
 
 def run(argv=sys.argv, _serve=serve):
     """Command line runner."""

--- a/waitress/runner.py
+++ b/waitress/runner.py
@@ -171,6 +171,18 @@ def show_help(stream, name, error=None): # pragma: no cover
         print('Error: {0}\n'.format(error), file=stream)
     print(HELP.format(name), file=stream)
 
+
+def show_exception(stream): # pragma: no cover
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    print(
+        'There was an exception ({0}) getting your module: "{1}" \n'.format(
+            exc_type,
+            exc_value
+        ),
+        file=stream
+    )
+
+
 def run(argv=sys.argv, _serve=serve):
     """Command line runner."""
     name = os.path.basename(argv[0])
@@ -193,6 +205,7 @@ def run(argv=sys.argv, _serve=serve):
         module, obj_name = match(args[0])
     except ValueError as exc:
         show_help(sys.stderr, name, str(exc))
+        show_exception(sys.stderr)
         return 1
 
     # Add the current directory onto sys.path
@@ -203,9 +216,11 @@ def run(argv=sys.argv, _serve=serve):
         app = resolve(module, obj_name)
     except ImportError:
         show_help(sys.stderr, name, "Bad module '{0}'".format(module))
+        show_exception(sys.stderr)
         return 1
     except AttributeError:
         show_help(sys.stderr, name, "Bad object name '{0}'".format(obj_name))
+        show_exception(sys.stderr)
         return 1
     if kw['call']:
         app = app()

--- a/waitress/tests/test_runner.py
+++ b/waitress/tests/test_runner.py
@@ -100,6 +100,16 @@ class Test_run(unittest.TestCase):
             1,
             "^Error: Bad module 'nonexistent'")
 
+        self.match_output(
+            ['nonexistent:a'],
+            1,
+            (
+                r"There was an exception \(ImportError\) importing your "
+                "module.\n\nIt had these arguments: \n"
+                "1. No module named 'nonexistent'"
+            )
+        )
+
     def test_cwd_added_to_path(self):
         def null_serve(app, **kw):
             pass
@@ -146,6 +156,43 @@ class Test_run(unittest.TestCase):
             'waitress.tests.fixtureapps.runner:returns_app',
         ]
         self.assertEqual(runner.run(argv=argv, _serve=check_server), 0)
+
+class Test_helper(unittest.TestCase):
+
+    def test_exception_logging(self):
+        from waitress.runner import show_exception
+
+        regex = (
+            r"There was an exception \(ImportError\) importing your module."
+            r"\n\nIt had these arguments: \n1. My reason"
+        )
+
+        with capture() as captured:
+            try:
+                raise ImportError("My reason")
+            except ImportError:
+                self.assertEqual(show_exception(sys.stderr), None)
+            self.assertRegexpMatches(
+                captured.getvalue(),
+                regex
+            )
+        captured.close()
+
+        regex = (
+            r"There was an exception \(ImportError\) importing your module."
+            r"\n\nIt had no arguments."
+        )
+
+        with capture() as captured:
+            try:
+                raise ImportError
+            except ImportError:
+                self.assertEqual(show_exception(sys.stderr), None)
+            self.assertRegexpMatches(
+                captured.getvalue(),
+                regex
+            )
+        captured.close()
 
 @contextlib.contextmanager
 def capture():

--- a/waitress/tests/test_runner.py
+++ b/waitress/tests/test_runner.py
@@ -106,7 +106,7 @@ class Test_run(unittest.TestCase):
             (
                 r"There was an exception \(ImportError\) importing your "
                 "module.\n\nIt had these arguments: \n"
-                "1. No module named 'nonexistent'"
+                "1. No module named '?nonexistent'?"
             )
         )
 


### PR DESCRIPTION
Added tests and made a new PR in response to feedback on PR #100.*

When waitress tries to import the WSGI application, errors are masked into a generic "Error: Bad Module". [Some people](http://stackoverflow.com/questions/22821597/waitress-on-heroku-giving-error/) find this unclear and/or confusing. This PR adds the name and value of the exception to the end of the error printing.

Optionally, the stacktrace could be printed as well, but is not included in the PR.

*: I understand convention to be starting a new PR when there are changes made.  Are there guidelines for this?