### PR TITLE
Allow passing a pre-created socket object via public API

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -13,6 +13,11 @@ host
 port
     TCP port (integer) on which to listen, default ``8080``
 
+sock
+    a pre-created socket object to accept connections on. If passed, ``host``,
+    ``port`` or ``unix_socket`` arguments are ignored. Useful for socket
+    activated applications.
+
 unix_socket
     Path of Unix socket (string), default is ``None``. If a socket path is
     specified, a Unix domain socket is made instead of the usual inet domain

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -36,6 +36,15 @@ def asoctal(s):
     """Convert the given octal string to an actual number."""
     return int(s, 8)
 
+def assocket(s):
+    """Ensure a valid socket object was passed and return it as is."""
+
+    if s and not isinstance(s, socket.socket):
+        name = type(s).__name__
+        raise TypeError('a %s was passed, but a socket is expected' % name)
+
+    return s
+
 def slash_fixed_str(s):
     s = s.strip()
     if s:
@@ -51,6 +60,7 @@ class Adjustments(object):
     _params = (
         ('host', str),
         ('port', int),
+        ('sock', assocket),
         ('threads', int),
         ('trusted_proxy', str),
         ('url_scheme', str),
@@ -81,6 +91,9 @@ class Adjustments(object):
 
     # TCP port to listen on
     port = 8080
+
+    # a pre-created socket to accept on
+    sock = None
 
     # mumber of threads available for tasks
     threads = 4

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -82,8 +82,8 @@ class BaseWSGIServer(logging_dispatcher, object):
         self.asyncore.dispatcher.__init__(self, _sock, map=map)
         if _sock is None:
             self.create_socket(self.family, socket.SOCK_STREAM)
-        self.set_reuse_addr()
-        self.bind_server_socket()
+            self.set_reuse_addr()
+            self.bind_server_socket()
         self.effective_host, self.effective_port = self.getsockname()
         self.server_name = self.get_server_name(self.adj.host)
         self.active_channels = {}

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -27,7 +27,6 @@ from waitress.utilities import cleanup_unix_socket, logging_dispatcher
 def create_server(application,
                   map=None,
                   _start=True,      # test shim
-                  _sock=None,       # test shim
                   _dispatcher=None, # test shim
                   **kw              # adjustments
                   ):
@@ -46,7 +45,7 @@ def create_server(application,
         cls = UnixWSGIServer
     else:
         cls = TcpWSGIServer
-    return cls(application, map, _start, _sock, _dispatcher, adj)
+    return cls(application, map, _start, _dispatcher, adj)
 
 class BaseWSGIServer(logging_dispatcher, object):
 
@@ -60,7 +59,6 @@ class BaseWSGIServer(logging_dispatcher, object):
                  application,
                  map=None,
                  _start=True,      # test shim
-                 _sock=None,       # test shim
                  _dispatcher=None, # test shim
                  adj=None,         # adjustments
                  **kw
@@ -79,11 +77,15 @@ class BaseWSGIServer(logging_dispatcher, object):
             _dispatcher = ThreadedTaskDispatcher()
             _dispatcher.set_thread_count(self.adj.threads)
         self.task_dispatcher = _dispatcher
-        self.asyncore.dispatcher.__init__(self, _sock, map=map)
-        if _sock is None:
+        self.asyncore.dispatcher.__init__(self, self.adj.sock, map=map)
+
+        # only create and bound a socket, if it hasn't been pre-created in
+        # advance (e.g. in a socket activated application)
+        if self.adj.sock is None:
             self.create_socket(self.family, socket.SOCK_STREAM)
             self.set_reuse_addr()
             self.bind_server_socket()
+
         self.effective_host, self.effective_port = self.getsockname()
         self.server_name = self.get_server_name(self.adj.host)
         self.active_channels = {}

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -22,6 +22,7 @@ class TestWSGIServer(unittest.TestCase):
     def _makeOneWithMap(self, adj=None, _start=True, host='127.0.0.1',
                         port=0, app=dummy_app):
         sock = DummySock()
+        sock.bind((host, port))
         task_dispatcher = DummyTaskDispatcher()
         map = {}
         return self._makeOne(

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -7,17 +7,18 @@ dummy_app = object()
 class TestWSGIServer(unittest.TestCase):
 
     def _makeOne(self, application=dummy_app, host='127.0.0.1', port=0,
-                 _dispatcher=None, adj=None, map=None, _start=True,
-                 _sock=None, _server=None):
+                 sock=None, _dispatcher=None, adj=None, map=None, _start=True,
+                 _server=None):
         from waitress.server import create_server
         return create_server(
             application,
             host=host,
             port=port,
+            sock=sock,
             map=map,
             _dispatcher=_dispatcher,
             _start=_start,
-            _sock=_sock)
+        )
 
     def _makeOneWithMap(self, adj=None, _start=True, host='127.0.0.1',
                         port=0, app=dummy_app):
@@ -30,7 +31,7 @@ class TestWSGIServer(unittest.TestCase):
             host=host,
             port=port,
             map=map,
-            _sock=sock,
+            sock=sock,
             _dispatcher=task_dispatcher,
             _start=_start,
         )
@@ -202,13 +203,13 @@ if hasattr(socket, 'AF_UNIX'):
     class TestUnixWSGIServer(unittest.TestCase):
         unix_socket = '/tmp/waitress.test.sock'
 
-        def _makeOne(self, _start=True, _sock=None):
+        def _makeOne(self, _start=True, sock=None):
             from waitress.server import create_server
             return create_server(
                 dummy_app,
                 map={},
                 _start=_start,
-                _sock=_sock,
+                sock=sock,
                 _dispatcher=DummyTaskDispatcher(),
                 unix_socket=self.unix_socket,
                 unix_socket_perms='600'
@@ -230,7 +231,7 @@ if hasattr(socket, 'AF_UNIX'):
             # by inet sockets.
             client = self._makeDummy()
             listen = self._makeDummy(acceptresult=(client, None))
-            inst = self._makeOne(_sock=listen)
+            inst = self._makeOne(sock=listen)
             self.assertEqual(inst.accepting, True)
             self.assertEqual(inst.socket.listened, 1024)
             L = []

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -243,7 +243,7 @@ if hasattr(socket, 'AF_UNIX'):
                 [(inst, client, ('localhost', None), inst.adj)]
             )
 
-class DummySock(object):
+class DummySock(socket.socket):
     accepted = False
     blocking = False
     family = socket.AF_INET


### PR DESCRIPTION
This would allow to write socket activated applications (e.g. to be activated by systemd lazily).
