### PR TITLE
Make tox pass positional arguments to nosetests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 [testenv]
 commands = 
     pip install waitress[testing]
-    nosetests --processes=4
+    nosetests --processes=4 {posargs}
 
 [testenv:cover]
 basepython =


### PR DESCRIPTION
E.g. this allows to run tests like:

  tox -epy27 -- --failed  # runs only the tests that failed last time

or:

  tox -epy27 -- --pdb  # start a pdb session on failures and errors

or use any other nosetests feature.
