### PR TITLE
Let the possibility to specify a wildcard for the truted_proxy var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'docs': docs_extras,
     },
     install_requires=[
-        'ipaddress>=1.0,<1.1',
+        'ipaddress',
     ],
     include_package_data=True,
     test_suite='waitress',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ setup(
         'testing': testing_extras,
         'docs': docs_extras,
     },
+    install_requires=[
+        'ipaddress>=1.0,<1.1',
+    ],
     include_package_data=True,
     test_suite='waitress',
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,14 @@ testing_extras = [
     'coverage',
 ]
 
+install_requires = []
+
 if sys.version_info[:2] == (2, 6):
     testing_extras.append('unittest2')
+
+if sys.version_info[:2] < (3, 3):
+    # the ipaddress package is part of Python 3.3+ standard librairies
+    install_requires.append('ipaddress')
 
 setup(
     name='waitress',
@@ -73,9 +79,7 @@ setup(
         'testing': testing_extras,
         'docs': docs_extras,
     },
-    install_requires=[
-        'ipaddress',
-    ],
+    install_requires=install_requires,
     include_package_data=True,
     test_suite='waitress',
     zip_safe=False,

--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -41,6 +41,11 @@ def text_(s, encoding='latin-1', errors='strict'):
     return s # pragma: no cover
 
 if PY3: # pragma: no cover
+    def tounicode(s):
+        if isinstance(s, binary_type):
+            return s.decode('latin-1')
+        return s
+
     def tostr(s):
         if isinstance(s, text_type):
             s = s.encode('latin-1')
@@ -49,6 +54,7 @@ if PY3: # pragma: no cover
     def tobytes(s):
         return bytes(s, 'latin-1')
 else:
+    tounicode = unicode
     tostr = str
 
     def tobytes(s):

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -492,8 +492,8 @@ class WSGITask(Task):
         headers = dict(request.headers)
         wsgi_url_scheme = request.url_scheme
         if server.adj.trusted_proxy:
-            net_mask = ip_network(u'%s' % server.adj.trusted_proxy)
-            ip_host = ip_address(u'%s' % host)
+            net_mask = ip_network(u'{}'.format(server.adj.trusted_proxy))
+            ip_host = ip_address(u'{}'.format(host))
             if ip_host in net_mask:
                 wsgi_url_scheme = headers.pop('X_FORWARDED_PROTO',
                                               request.url_scheme)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 
+from __future__ import unicode_literals
+
 import socket
 import sys
 import threading
@@ -492,8 +494,8 @@ class WSGITask(Task):
         headers = dict(request.headers)
         wsgi_url_scheme = request.url_scheme
         if server.adj.trusted_proxy:
-            net_mask = ip_network(u'{0}'.format(server.adj.trusted_proxy))
-            ip_host = ip_address(u'{0}'.format(host))
+            net_mask = ip_network('{0}'.format(server.adj.trusted_proxy))
+            ip_host = ip_address('{0}'.format(host))
             if ip_host in net_mask:
                 wsgi_url_scheme = headers.pop('X_FORWARDED_PROTO',
                                               request.url_scheme)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -492,8 +492,8 @@ class WSGITask(Task):
         headers = dict(request.headers)
         wsgi_url_scheme = request.url_scheme
         if server.adj.trusted_proxy:
-            net_mask = ip_network(u'{}'.format(server.adj.trusted_proxy))
-            ip_host = ip_address(u'{}'.format(host))
+            net_mask = ip_network(u'{0}'.format(server.adj.trusted_proxy))
+            ip_host = ip_address(u'{0}'.format(host))
             if ip_host in net_mask:
                 wsgi_url_scheme = headers.pop('X_FORWARDED_PROTO',
                                               request.url_scheme)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -12,8 +12,6 @@
 #
 ##############################################################################
 
-from __future__ import unicode_literals
-
 import socket
 import sys
 import threading
@@ -25,6 +23,7 @@ from waitress.buffers import ReadOnlyFileBasedBuffer
 
 from waitress.compat import (
     tobytes,
+    tounicode,
     Queue,
     Empty,
     reraise,
@@ -494,8 +493,8 @@ class WSGITask(Task):
         headers = dict(request.headers)
         wsgi_url_scheme = request.url_scheme
         if server.adj.trusted_proxy:
-            net_mask = ip_network('{0}'.format(server.adj.trusted_proxy))
-            ip_host = ip_address('{0}'.format(host))
+            net_mask = ip_network(tounicode(server.adj.trusted_proxy))
+            ip_host = ip_address(tounicode(host))
             if ip_host in net_mask:
                 wsgi_url_scheme = headers.pop('X_FORWARDED_PROTO',
                                               request.url_scheme)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -488,7 +488,7 @@ class WSGITask(Task):
         host = environ['REMOTE_ADDR'] = channel.addr[0]
 
         headers = dict(request.headers)
-        if host == server.adj.trusted_proxy:
+        if server.adj.trusted_proxy == '*' or host == server.adj.trusted_proxy:
             wsgi_url_scheme = headers.pop('X_FORWARDED_PROTO',
                                           request.url_scheme)
         else:


### PR DESCRIPTION
Here is a suggestion to use the `X_FORWARDED_PROTO` on cloud based reversed proxies with no fixed ip.

I don't see any personal objection on allowing the wildcard if it is documented well enough for this particular case.

Cheers
