### PR TITLE
Disallow control characters (\n\r) in start_response's headers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Next release
 ------------
 
+- Waitress will no longer accept headers with newline/carriage returns in them,
+  thereby disallowing HTTP Response Splitting. See
+  https://github.com/Pylons/waitress/issues/117 for more information, as well
+  as https://www.owasp.org/index.php/HTTP_Response_Splitting.
+
 - Call prune() on the output buffer at the end of a request so that it doesn't
   continue to grow without bounds. See
   https://github.com/Pylons/waitress/issues/111 for more information.

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -371,6 +371,10 @@ class WSGITask(Task):
                     raise AssertionError(
                         'Header value %r is not a string in %r' % (v, (k, v))
                     )
+
+                if '\n' in v or '\r' in v:
+                    raise ValueError("carriage return/line "
+                                     "feed character present in header value")
                 kl = k.lower()
                 if kl == 'content-length':
                     self.content_length = int(v)

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -409,6 +409,13 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         self.assertRaises(AssertionError, inst.execute)
 
+    def test_execute_bad_header_value_control_characters(self):
+        def app(environ, start_response):
+            start_response('200 OK', [('a', '\n')])
+        inst = self._makeOne()
+        inst.channel.server.application = app
+        self.assertRaises(ValueError, inst.execute)
+
     def test_preserve_header_value_order(self):
         def app(environ, start_response):
             write = start_response('200 OK', [('C', 'b'), ('A', 'b'), ('A', 'a')])


### PR DESCRIPTION
This stops HTTP Response Splitting and follows in the footsteps of mod_wsgi in verifying that the headers don't contain the control characters.