### PR TITLE
Fixed problem with unicode being recognised as not string in headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if sys.version_info[:2] == (2, 6):
 
 setup(
     name='waitress',
-    version='0.9.0b1',
+    version='0.9.0b1-dev1',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     maintainer="Chris McDonough",

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -31,6 +31,12 @@ from waitress.utilities import (
     logger,
 )
 
+try:
+      basestring
+except NameError:
+      basestring = (str, bytes)
+
+
 rename_headers = {  # or keep them without the HTTP_ prefix added
     'CONTENT_LENGTH': 'CONTENT_LENGTH',
     'CONTENT_TYPE': 'CONTENT_TYPE',
@@ -366,11 +372,11 @@ class WSGITask(Task):
 
             # Prepare the headers for output
             for k, v in headers:
-                if not k.__class__ is str:
+                if not isinstance(k, basestring):
                     raise AssertionError(
                         'Header name %r is not a string in %r' % (k, (k, v))
                     )
-                if not v.__class__ is str:
+                if not isinstance(v, basestring):
                     raise AssertionError(
                         'Header value %r is not a string in %r' % (v, (k, v))
                     )


### PR DESCRIPTION
In Python 2.7.11 header value is unicode and it fails due to check to `str`. 

PR fixes this issue.