### PR TITLE
On Windows, turn port into an integer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27"
     - PYTHON: "C:\\Python35"
       TOXENV: "py35"
 

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -17,8 +17,9 @@ import getopt
 import socket
 
 from waitress.compat import (
-    string_types,
+    PY2,
     WIN,
+    string_types,
     )
 
 truthy = frozenset(('t', 'true', 'y', 'yes', 'on', '1'))
@@ -245,7 +246,7 @@ class Adjustments(object):
             else:
                 (host, port) = (i, str(self.port))
 
-            if WIN: # pragma: no cover
+            if WIN and PY2: # pragma: no cover
                 try:
                     # Try turning the port into an integer
                     port = int(port)

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -16,7 +16,10 @@
 import getopt
 import socket
 
-from waitress.compat import string_types
+from waitress.compat import (
+    string_types,
+    WIN,
+    )
 
 truthy = frozenset(('t', 'true', 'y', 'yes', 'on', '1'))
 
@@ -241,6 +244,15 @@ class Adjustments(object):
                     (host, port) = (i, str(self.port))
             else:
                 (host, port) = (i, str(self.port))
+
+            if WIN: # pragma: no cover
+                try:
+                    # Try turning the port into an integer
+                    port = int(port)
+                except:
+                    raise ValueError(
+                        'Windows does not support service names instead of port numbers'
+                    )
 
             try:
                 if '[' in host and ']' in host: # pragma: nocover

--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import platform
 
 try:
     import urlparse
@@ -8,6 +9,9 @@ except ImportError: # pragma: no cover
 
 # True if we are running on Python 3.
 PY3 = sys.version_info[0] == 3
+
+# True if we are running on Windows
+WIN = platform.system() == 'Windows'
 
 if PY3: # pragma: no cover
     string_types = str,

--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -8,6 +8,7 @@ except ImportError: # pragma: no cover
     from urllib import parse as urlparse
 
 # True if we are running on Python 3.
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 # True if we are running on Windows

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -1,6 +1,11 @@
 import sys
 import socket
 
+from waitress.compat import (
+    PY2,
+    WIN,
+    )
+
 if sys.version_info[:2] == (2, 6): # pragma: no cover
     import unittest2 as unittest
 else: # pragma: no cover
@@ -181,6 +186,15 @@ class TestAdjustments(unittest.TestCase):
         self.assertRaises(ValueError, self._makeOne, listen='127.0.0.1:test')
 
     def test_service_port(self):
+        if WIN and PY2: # pragma: no cover
+            # On Windows and Python 2 this is broken, so we raise a ValueError
+            self.assertRaises(
+                ValueError,
+                self._makeOne,
+                listen='127.0.0.1:http',
+            )
+            return
+
         inst = self._makeOne(listen='127.0.0.1:http 0.0.0.0:https')
 
         bind_pairs = [sockaddr[:2] for (_, _, _, sockaddr) in inst.listen]


### PR DESCRIPTION
We can't use service names instead of port numbers on Windows, so
attempt to turn the port into an integer. If unable to do so, raise an
error.

Requires #140 as well...

Closes #139 