### PR TITLE
undo canonical_url theme option because RTD has it already configured

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,10 +91,7 @@ pygments_style = 'sphinx'
 # Add and use Pylons theme
 html_theme = 'pylons'
 html_theme_path = pylons_sphinx_themes.get_html_themes_path()
-html_theme_options = dict(
-    github_url='http://github.com/Pylons/waitress',
-    canonical_url='http://docs.pylonsproject.org/projects/waitress/en/latest/'
-)
+html_theme_options = dict(github_url='http://github.com/Pylons/waitress')
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths

--- a/rtd.txt
+++ b/rtd.txt
@@ -1,3 +1,3 @@
-Sphinx >= 1.2.3
+Sphinx >= 1.3.1
 repoze.sphinx.autointerface
 pylons-sphinx-themes


### PR DESCRIPTION
- Where is this configured? No idea. See https://github.com/Pylons/waitress/pull/143