### PR TITLE
possible fix for PR #146

### DIFF
--- a/docs/filewrapper.rst
+++ b/docs/filewrapper.rst
@@ -3,7 +3,9 @@ Support for ``wsgi.file_wrapper``
 
 Waitress supports the `WSGI file_wrapper protocol
 <http://www.python.org/dev/peps/pep-0333/#optional-platform-specific-file-handling>`_
-.  Here's a usage example::
+.  Here's a usage example:
+
+.. code-block:: python
 
     import os
 


### PR DESCRIPTION
- Recent Sphinx versions might break on the `::` syntax, so use explicit `.. code-block:: python` instead