### PR TITLE
Add fallback to numeric only nameinfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ matrix:
           env: TOXENV=py35
         - python: pypy
           env: TOXENV=pypy
+        - python: pypy3
+          env: TOXENV=pypy3
         - python: 3.5
           env: TOXENV=py2-cover,py3-cover,coverage
         - python: 3.5
           env: TOXENV=docs
+    allow_failures:
+        - env: TOXENV=pypy3
 
 install:
   - travis_retry pip install tox


### PR DESCRIPTION
This adds a fallback so that if we get an exception on the first `getnameinfo` we fall-back to calling it with full numeric support. This should always succeed, and return valid information.

Closes #149 
