### PR TITLE
Fix issue #64 Uncaptured exception instead of 400 when receiving non-ascii bytes in request url

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,5 @@ Contributors
 - Jason Madden, 2016-03-19
 
 - Atsushi Odagiri, 2017-02-12
+
+- David D Lowe, 2017-06-02

--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -253,7 +253,10 @@ class HTTPRequestParser(object):
 def split_uri(uri):
     # urlsplit handles byte input by returning bytes on py3, so
     # scheme, netloc, path, query, and fragment are bytes
-    scheme, netloc, path, query, fragment = urlparse.urlsplit(uri)
+    try:
+        scheme, netloc, path, query, fragment = urlparse.urlsplit(uri)
+    except UnicodeError:
+        raise ParsingError('Bad URI')
     return (
         tostr(scheme),
         tostr(netloc),

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -249,6 +249,11 @@ class Test_split_uri(unittest.TestCase):
         self.assertEqual(self.proxy_scheme, 'https')
         self.assertEqual(self.proxy_netloc, 'localhost:8080')
 
+    def test_split_uri_unicode_error_raises_parsing_error(self):
+        # See https://github.com/Pylons/waitress/issues/64
+        from waitress.parser import ParsingError
+        self.assertRaises(ParsingError, self._callFUT, b'/\xd0')
+
 class Test_get_header_lines(unittest.TestCase):
 
     def _callFUT(self, data):

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -252,7 +252,12 @@ class Test_split_uri(unittest.TestCase):
     def test_split_uri_unicode_error_raises_parsing_error(self):
         # See https://github.com/Pylons/waitress/issues/64
         from waitress.parser import ParsingError
-        self.assertRaises(ParsingError, self._callFUT, b'/\xd0')
+        # Either pass or throw a ParsingError, just don't throw another type of
+        # exception as that will cause the connection to close badly:
+        try:
+            self._callFUT(b'/\xd0')
+        except ParsingError:
+            pass
 
 class Test_get_header_lines(unittest.TestCase):
 


### PR DESCRIPTION
I took the existing `fix.issue64` branch, rebased it, and added a new commit. This is a fix for #64.

This makes the new test pass in both Python 2 and 3. It doesn't matter that Python 2 doesn't raise a ParsingError, all that matters is that the connection isn't closed abruptly, and the test verifies that that remains the case for both Python 2 and Python 3.