### PR TITLE
MUST NOT send Transfer-Encoding or Content-Length for 1xx or 204

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -231,8 +231,12 @@ class Task(object):
                 close_on_finish()
 
             if not content_length_header:
-                response_headers.append(('Transfer-Encoding', 'chunked'))
-                self.chunked_response = True
+                # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
+                # for any response with a status code of 1xx or 204.
+                if not (self.status.startswith('1') or
+                        self.status.startswith('204')):
+                    response_headers.append(('Transfer-Encoding', 'chunked'))
+                    self.chunked_response = True
                 if not self.close_on_finish:
                     close_on_finish()
 

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -219,6 +219,23 @@ class TestTask(unittest.TestCase):
         self.assertEqual(inst.close_on_finish, True)
         self.assertTrue(('Connection', 'close') in inst.response_headers)
 
+    def test_build_response_header_v11_1xx_no_content_length_or_transfer_encoding(self):
+        # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
+        # for any response with a status code of 1xx or 204.
+        inst = self._makeOne()
+        inst.request = DummyParser()
+        inst.version = '1.1'
+        inst.status = '100 Continue'
+        result = inst.build_response_header()
+        lines = filter_lines(result)
+        self.assertEqual(len(lines), 4)
+        self.assertEqual(lines[0], b'HTTP/1.1 100 Continue')
+        self.assertEqual(lines[1], b'Connection: close')
+        self.assertTrue(lines[2].startswith(b'Date:'))
+        self.assertEqual(lines[3], b'Server: waitress')
+        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(('Connection', 'close') in inst.response_headers)
+
     def test_build_response_header_via_added(self):
         inst = self._makeOne()
         inst.request = DummyParser()

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -202,6 +202,23 @@ class TestTask(unittest.TestCase):
         self.assertEqual(inst.close_on_finish, True)
         self.assertTrue(('Connection', 'close') in inst.response_headers)
 
+    def test_build_response_header_v11_204_no_content_length_or_transfer_encoding(self):
+        # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
+        # for any response with a status code of 1xx or 204.
+        inst = self._makeOne()
+        inst.request = DummyParser()
+        inst.version = '1.1'
+        inst.status = '204 No Content'
+        result = inst.build_response_header()
+        lines = filter_lines(result)
+        self.assertEqual(len(lines), 4)
+        self.assertEqual(lines[0], b'HTTP/1.1 204 No Content')
+        self.assertEqual(lines[1], b'Connection: close')
+        self.assertTrue(lines[2].startswith(b'Date:'))
+        self.assertEqual(lines[3], b'Server: waitress')
+        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(('Connection', 'close') in inst.response_headers)
+
     def test_build_response_header_via_added(self):
         inst = self._makeOne()
         inst.request = DummyParser()


### PR DESCRIPTION
Fixes #165 