### PR TITLE
No longer allow lowercase HTTP methods

### DIFF
--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -291,8 +291,20 @@ def crack_first_line(line):
             version = m.group(5)
         else:
             version = None
-        command = m.group(1).upper()
+        method = m.group(1)
+
+        # the request methods that are currently defined are all uppercase:
+        # https://www.iana.org/assignments/http-methods/http-methods.xhtml and
+        # the request method is case sensitive according to
+        # https://tools.ietf.org/html/rfc7231#section-4.1
+
+        # By disallowing anything but uppercase methods we save poor
+        # unsuspecting souls from sending lowercase HTTP methods to waitress
+        # and having the request complete, while servers like nginx drop the
+        # request onto the floor.
+        if method != method.upper():
+            raise ParsingError('Malformed HTTP method "%s"' % tostr(method))
         uri = m.group(2)
-        return command, uri, version
+        return method, uri, version
     else:
         return b'', b'', b''

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -288,15 +288,19 @@ class Test_crack_first_line(unittest.TestCase):
         return crack_first_line(line)
 
     def test_crack_first_line_matchok(self):
-        result = self._callFUT(b'get / HTTP/1.0')
+        result = self._callFUT(b'GET / HTTP/1.0')
         self.assertEqual(result, (b'GET', b'/', b'1.0'))
 
+    def test_crack_first_line_lowercase_method(self):
+        from waitress.parser import ParsingError
+        self.assertRaises(ParsingError, self._callFUT, b'get / HTTP/1.0')
+
     def test_crack_first_line_nomatch(self):
-        result = self._callFUT(b'get / bleh')
+        result = self._callFUT(b'GET / bleh')
         self.assertEqual(result, (b'', b'', b''))
 
     def test_crack_first_line_missing_version(self):
-        result = self._callFUT(b'get /')
+        result = self._callFUT(b'GET /')
         self.assertEqual(result, (b'GET', b'/', None))
 
 class TestHTTPRequestParserIntegration(unittest.TestCase):


### PR DESCRIPTION
RFC 7231 specifies that methods are case sensitive, and by convention are all uppercase: https://tools.ietf.org/html/rfc7231#section-4.1

> This specification defines a number of standardized methods that are
>   commonly used in HTTP, as outlined by the following table.  By
>   convention, standardized methods are defined in all-uppercase
>   US-ASCII letters.

https://tools.ietf.org/html/rfc7231#section-8.1 specifies that there is a registry for all of the HTTP methods that exist, which is available here: https://www.iana.org/assignments/http-methods/http-methods.xhtml (in other news, there are a lot more there than I was aware of :P)

All of them are uppercase.

I recently ran into an interesting issue, I was using the new `fetch()` function in JavaScript and it allowed me to send a `post` request instead of a `POST` request. nginx dropped the request on the floor, but waitress locally was allowing it by just calling `.upper()` on the method.

This change brings things more in line with all other HTTP servers, and disallows anything put an uppercase HTTP method thereby hopefully making it harder to have differences between prod and devel...