### PR TITLE
Log warning when queue depth is greater than 0

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -108,6 +108,11 @@ class ThreadedTaskDispatcher(object):
                     running -= 1
 
     def add_task(self, task):
+        queue_depth = self.queue.qsize()
+        if queue_depth > 0:
+            self.logger.warning(
+                "Task queue depth is %d" %
+                queue_depth)
         try:
             task.defer()
             self.queue.put(task)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -29,6 +29,7 @@ from waitress.compat import (
 from waitress.utilities import (
     build_http_date,
     logger,
+    queue_logger,
 )
 
 rename_headers = {  # or keep them without the HTTP_ prefix added
@@ -55,6 +56,7 @@ class ThreadedTaskDispatcher(object):
     """
     stop_count = 0 # Number of threads that will stop soon.
     logger = logger
+    queue_logger = queue_logger
 
     def __init__(self):
         self.threads = {} # { thread number -> 1 }
@@ -110,7 +112,7 @@ class ThreadedTaskDispatcher(object):
     def add_task(self, task):
         queue_depth = self.queue.qsize()
         if queue_depth > 0:
-            self.logger.warning(
+            self.queue_logger.warning(
                 "Task queue depth is %d" %
                 queue_depth)
         try:

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -65,6 +65,13 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         self.assertEqual(inst.queue.qsize(), 1)
         self.assertTrue(task.deferred)
 
+    def test_log_queue_depth(self):
+        task = DummyTask()
+        inst = self._makeOne()
+        inst.add_task(task)
+        inst.logger = DummyLogger()
+        self.assertEqual(len(inst.logger.logged), 1)
+
     def test_add_task_defer_raises(self):
         task = DummyTask(ValueError)
         inst = self._makeOne()

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -68,8 +68,10 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
     def test_log_queue_depth(self):
         task = DummyTask()
         inst = self._makeOne()
-        inst.add_task(task)
         inst.logger = DummyLogger()
+        inst.add_task(task)
+        self.assertEqual(len(inst.logger.logged), 0)
+        inst.add_task(task)
         self.assertEqual(len(inst.logger.logged), 1)
 
     def test_add_task_defer_raises(self):

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -68,11 +68,11 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
     def test_log_queue_depth(self):
         task = DummyTask()
         inst = self._makeOne()
-        inst.logger = DummyLogger()
+        inst.queue_logger = DummyLogger()
         inst.add_task(task)
-        self.assertEqual(len(inst.logger.logged), 0)
+        self.assertEqual(len(inst.queue_logger.logged), 0)
         inst.add_task(task)
-        self.assertEqual(len(inst.logger.logged), 1)
+        self.assertEqual(len(inst.queue_logger.logged), 1)
 
     def test_add_task_defer_raises(self):
         task = DummyTask(ValueError)

--- a/waitress/utilities.py
+++ b/waitress/utilities.py
@@ -24,6 +24,7 @@ import time
 import calendar
 
 logger = logging.getLogger('waitress')
+queue_logger = logging.getLogger('waitress.queue')
 
 def find_double_newline(s):
     """Returns the position just after a double newline in the given string."""


### PR DESCRIPTION
It's currently hard to tell when an application is under-provisioned with server processes or threads, causing requests to queue up. This change logs a warning when a new task is added but the queue depth is greater than 0.