### PR TITLE
Support configurably omitting server header

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+Unreleased (2018-05-21)
+-----------------------
+
+Features
+~~~~~~~~
+
+- Server header can be omitted by specifying `ident=None` or `ident=''`.
+  See https://github.com/Pylons/waitress/pull/187
+
+
 1.1.0 (2017-10-10)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -140,3 +140,5 @@ Contributors
 - Atsushi Odagiri, 2017-02-12
 
 - David D Lowe, 2017-06-02
+
+- Jack Wearden, 2018-05-18

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -66,10 +66,8 @@ def slash_fixed_str(s):
         s = '/' + s.lstrip('/').rstrip('/')
     return s
 
-def str_ifnotnone(s):
-    if s is None:
-        return None
-    return str(s)
+def str_iftruthy(s):
+    return str(s) if s else s
 
 class _str_marker(str):
     pass
@@ -103,7 +101,7 @@ class Adjustments(object):
         ('max_request_header_size', int),
         ('max_request_body_size', int),
         ('expose_tracebacks', asbool),
-        ('ident', str_ifnotnone),
+        ('ident', str_iftruthy),
         ('asyncore_loop_timeout', int),
         ('asyncore_use_poll', asbool),
         ('unix_socket', str),

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -66,6 +66,11 @@ def slash_fixed_str(s):
         s = '/' + s.lstrip('/').rstrip('/')
     return s
 
+def str_ifnotnone(s):
+    if s is None:
+        return None
+    return str(s)
+
 class _str_marker(str):
     pass
 
@@ -98,7 +103,7 @@ class Adjustments(object):
         ('max_request_header_size', int),
         ('max_request_body_size', int),
         ('expose_tracebacks', asbool),
-        ('ident', str),
+        ('ident', str_ifnotnone),
         ('asyncore_loop_timeout', int),
         ('asyncore_use_poll', asbool),
         ('unix_socket', str),

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -67,7 +67,7 @@ def slash_fixed_str(s):
     return s
 
 def str_iftruthy(s):
-    return str(s) if s else s
+    return str(s) if s else None
 
 class _str_marker(str):
     pass

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -250,10 +250,12 @@ class Task(object):
         # Set the Server and Date field, if not yet specified. This is needed
         # if the server is used as a proxy.
         ident = self.channel.server.adj.ident
-        if not server_header:
-            response_headers.append(('Server', ident))
-        else:
-            response_headers.append(('Via', ident))
+        if ident is not None:
+            if not server_header:
+                response_headers.append(('Server', ident))
+            else:
+                response_headers.append(('Via', ident))
+
         if not date_header:
             response_headers.append(('Date', build_http_date(self.start_time)))
 

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -254,7 +254,7 @@ class Task(object):
             if ident:
                 response_headers.append(('Server', ident))
         else:
-            response_headers.append(('Via', ident))
+            response_headers.append(('Via', ident or 'waitress'))
 
         if not date_header:
             response_headers.append(('Date', build_http_date(self.start_time)))

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -250,11 +250,11 @@ class Task(object):
         # Set the Server and Date field, if not yet specified. This is needed
         # if the server is used as a proxy.
         ident = self.channel.server.adj.ident
-        if ident is not None:
-            if not server_header:
+        if not server_header:
+            if ident:
                 response_headers.append(('Server', ident))
-            else:
-                response_headers.append(('Via', ident))
+        else:
+            response_headers.append(('Via', ident))
 
         if not date_header:
             response_headers.append(('Date', build_http_date(self.start_time)))

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -224,7 +224,7 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.ident, None)
 
         inst = self._makeOne(ident='')
-        self.assertEqual(inst.ident, '')
+        self.assertEqual(inst.ident, None)
 
         inst = self._makeOne(ident='specific_header')
         self.assertEqual(inst.ident, 'specific_header')

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -219,6 +219,17 @@ class TestAdjustments(unittest.TestCase):
     def test_ipv6_disabled(self):
         self.assertRaises(ValueError, self._makeOne, ipv6=False, listen="[::]:8080")
 
+    def test_server_header_removable(self):
+        inst = self._makeOne(ident=None)
+        self.assertEqual(inst.ident, None)
+
+        inst = self._makeOne(ident='')
+        self.assertEqual(inst.ident, '')
+
+        inst = self._makeOne(ident='specific_headaer')
+        self.assertEqual(inst.ident, 'specific_header')
+
+
 class TestCLI(unittest.TestCase):
 
     def parse(self, argv):

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -226,7 +226,7 @@ class TestAdjustments(unittest.TestCase):
         inst = self._makeOne(ident='')
         self.assertEqual(inst.ident, '')
 
-        inst = self._makeOne(ident='specific_headaer')
+        inst = self._makeOne(ident='specific_header')
         self.assertEqual(inst.ident, 'specific_header')
 
 

--- a/waitress/tests/test_init.py
+++ b/waitress/tests/test_init.py
@@ -14,12 +14,6 @@ class Test_serve(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(server.ran, True)
 
-    def test_empty_server_header(self):
-        server = DummyServerFactory()
-        app = object()
-        result = self._callFUT(app, _server=server, _quiet=True, ident=None)
-        self.assertIsNone(server.adj.ident)
-
 
 class Test_serve_paste(unittest.TestCase):
 

--- a/waitress/tests/test_init.py
+++ b/waitress/tests/test_init.py
@@ -14,6 +14,13 @@ class Test_serve(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(server.ran, True)
 
+    def test_empty_server_header(self):
+        server = DummyServerFactory()
+        app = object()
+        result = self._callFUT(app, _server=server, _quiet=True, ident=None)
+        self.assertIsNone(server.adj.ident)
+
+
 class Test_serve_paste(unittest.TestCase):
 
     def _callFUT(self, app, **kw):


### PR DESCRIPTION
Hello Waitress Project!

We use Waitress in a number of our projects and recently noticed that it's not possible to withhold the Server header from HTTP responses, with the closest option being to set it to an empty string.

In line with the suggestion of configurability in RFC2616[0] we've filed this PR to add support for this choice by specifying `waitress.serve(ident=None)`.

Hope this is helpful.

Thanks!

[0] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.38