### PR TITLE
Ignore response body if status code doesn't allow a body

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -182,6 +182,13 @@ class Task(object):
         finally:
             pass
 
+    @property
+    def has_body(self):
+        return not (self.status.startswith('1') or
+                    self.status.startswith('204') or
+                    self.status.startswith('304')
+                    )
+
     def cancel(self):
         self.close_on_finish = True
 
@@ -239,11 +246,12 @@ class Task(object):
 
             if not content_length_header:
                 # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
-                # for any response with a status code of 1xx or 204.
-                if not (self.status.startswith('1') or
-                        self.status.startswith('204')):
+                # for any response with a status code of 1xx, 204 or 304.
+
+                if self.has_body:
                     response_headers.append(('Transfer-Encoding', 'chunked'))
                     self.chunked_response = True
+
                 if not self.close_on_finish:
                     close_on_finish()
 

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -200,31 +200,33 @@ class Task(object):
         version = self.version
         # Figure out whether the connection should be closed.
         connection = self.request.headers.get('CONNECTION', '').lower()
-        response_headers = self.response_headers
+        response_headers = []
         content_length_header = None
         date_header = None
         server_header = None
         connection_close_header = None
 
-        for i, (headername, headerval) in enumerate(response_headers):
+        for (headername, headerval) in self.response_headers:
             headername = '-'.join(
                 [x.capitalize() for x in headername.split('-')]
             )
+
             if headername == 'Content-Length':
                 if self.has_body:
                     content_length_header = headerval
                 else:
-                    del response_headers[i]
                     continue  # pragma: no cover
 
             if headername == 'Date':
                 date_header = headerval
+
             if headername == 'Server':
                 server_header = headerval
+
             if headername == 'Connection':
                 connection_close_header = headerval.lower()
             # replace with properly capitalized version
-            response_headers[i] = (headername, headerval)
+            response_headers.append((headername, headerval))
 
         if (
             content_length_header is None and
@@ -232,7 +234,7 @@ class Task(object):
             self.has_body
         ):
             content_length_header = str(self.content_length)
-            self.response_headers.append(
+            response_headers.append(
                 ('Content-Length', content_length_header)
             )
 
@@ -272,6 +274,7 @@ class Task(object):
         # Set the Server and Date field, if not yet specified. This is needed
         # if the server is used as a proxy.
         ident = self.channel.server.adj.ident
+
         if not server_header:
             if ident:
                 response_headers.append(('Server', ident))
@@ -281,20 +284,28 @@ class Task(object):
         if not date_header:
             response_headers.append(('Date', build_http_date(self.start_time)))
 
+        self.response_headers = response_headers
+
         first_line = 'HTTP/%s %s' % (self.version, self.status)
         # NB: sorting headers needs to preserve same-named-header order
         # as per RFC 2616 section 4.2; thus the key=lambda x: x[0] here;
         # rely on stable sort to keep relative position of same-named headers
         next_lines = ['%s: %s' % hv for hv in sorted(
-                self.response_headers, key=lambda x: x[0])]
+            self.response_headers, key=lambda x: x[0])]
         lines = [first_line] + next_lines
         res = '%s\r\n\r\n' % '\r\n'.join(lines)
+
         return tobytes(res)
 
     def remove_content_length_header(self):
-        for i, (header_name, header_value) in enumerate(self.response_headers):
+        response_headers = []
+
+        for header_name, header_value in self.response_headers:
             if header_name.lower() == 'content-length':
-                del self.response_headers[i]
+                continue  # pragma: nocover
+            response_headers.append((header_name, header_value))
+
+        self.response_headers = response_headers
 
     def start(self):
         self.start_time = time.time()

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -308,6 +308,12 @@ class TestTask(unittest.TestCase):
         inst.remove_content_length_header()
         self.assertEqual(inst.response_headers, [])
 
+    def test_remove_content_length_header_with_other(self):
+        inst = self._makeOne()
+        inst.response_headers = [('Content-Length', '70'), ('Content-Type', 'text/html')]
+        inst.remove_content_length_header()
+        self.assertEqual(inst.response_headers, [('Content-Type', 'text/html')])
+
     def test_start(self):
         inst = self._makeOne()
         inst.start()

--- a/waitress/tests/test_wasyncore.py
+++ b/waitress/tests/test_wasyncore.py
@@ -915,9 +915,10 @@ class BaseTestAPI:
                 self.flag = True
                 self.close()
 
-            # def handle_expt(self):
-            #     self.flag = True
-            #     self.close()
+            def handle_expt(self):  # pragma: no cover
+                                    # needs to exist for MacOS testing
+                self.flag = True
+                self.close()
 
         class TestHandler(BaseTestHandler):
 


### PR DESCRIPTION
This is a follow-up to https://github.com/Pylons/waitress/pull/166 and fixes the issue presented in https://github.com/Pylons/waitress/issues/197.

This goes a step further than just making sure waitress doesn't generate any extra headers/content, it also removes it even if the application sent data it shouldn't have. This will help make sure that message bodies are not accidentally sent with HTTP status codes that SHOULD NOT contain message bodies.

Closes https://github.com/Pylons/waitress/issues/197