### PR TITLE
Set wsgi.input_terminated in the WSGI environ

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -536,6 +536,7 @@ class WSGITask(Task):
         environ['wsgi.run_once'] = False
         environ['wsgi.input'] = request.get_body_stream()
         environ['wsgi.file_wrapper'] = ReadOnlyFileBasedBuffer
+        environ['wsgi.input_terminated'] = True # wsgi.input is EOF terminated
 
         self.environ = environ
         return environ

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -704,8 +704,8 @@ class TestWSGITask(unittest.TestCase):
             'PATH_INFO', 'QUERY_STRING', 'REMOTE_ADDR', 'REQUEST_METHOD',
             'SCRIPT_NAME', 'SERVER_NAME', 'SERVER_PORT', 'SERVER_PROTOCOL',
             'SERVER_SOFTWARE', 'wsgi.errors', 'wsgi.file_wrapper', 'wsgi.input',
-            'wsgi.multiprocess', 'wsgi.multithread', 'wsgi.run_once',
-            'wsgi.url_scheme', 'wsgi.version'])
+            'wsgi.input_terminated', 'wsgi.multiprocess', 'wsgi.multithread',
+            'wsgi.run_once', 'wsgi.url_scheme', 'wsgi.version'])
 
         self.assertEqual(environ['REQUEST_METHOD'], 'GET')
         self.assertEqual(environ['SERVER_PORT'], '80')
@@ -727,6 +727,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(environ['wsgi.multiprocess'], False)
         self.assertEqual(environ['wsgi.run_once'], False)
         self.assertEqual(environ['wsgi.input'], 'stream')
+        self.assertEqual(environ['wsgi.input_terminated'], True)
         self.assertEqual(inst.environ, environ)
 
     def test_get_environment_values_w_scheme_override_untrusted(self):
@@ -767,8 +768,8 @@ class TestWSGITask(unittest.TestCase):
             'PATH_INFO', 'QUERY_STRING', 'REMOTE_ADDR', 'REQUEST_METHOD',
             'SCRIPT_NAME', 'SERVER_NAME', 'SERVER_PORT', 'SERVER_PROTOCOL',
             'SERVER_SOFTWARE', 'wsgi.errors', 'wsgi.file_wrapper', 'wsgi.input',
-            'wsgi.multiprocess', 'wsgi.multithread', 'wsgi.run_once',
-            'wsgi.url_scheme', 'wsgi.version'])
+            'wsgi.input_terminated', 'wsgi.multiprocess', 'wsgi.multithread',
+            'wsgi.run_once', 'wsgi.url_scheme', 'wsgi.version'])
 
         self.assertEqual(environ['REQUEST_METHOD'], 'GET')
         self.assertEqual(environ['SERVER_PORT'], '80')
@@ -790,6 +791,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(environ['wsgi.multiprocess'], False)
         self.assertEqual(environ['wsgi.run_once'], False)
         self.assertEqual(environ['wsgi.input'], 'stream')
+        self.assertEqual(environ['wsgi.input_terminated'], True)
         self.assertEqual(inst.environ, environ)
 
     def test_get_environment_values_w_bogus_scheme_override(self):


### PR DESCRIPTION
This is a no-op because Waitress already buffers the entire request if
it is chunked and will correctly set the CONTENT_LENGTH, but it may
allow optimizations in certain WSGI applications/libraries.

Closes https://github.com/Pylons/waitress/issues/179