### PR TITLE
Allow passing of sockets for socket activation

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -142,3 +142,5 @@ Contributors
 - David D Lowe, 2017-06-02
 
 - Jack Wearden, 2018-05-18
+
+- Frank Krick, 2018-10-29

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -52,12 +52,13 @@ unix_socket_perms
     ``600``. Only used if ``unix_socket`` is not ``None``.
 
 sockets
-    A list of sockets. The sockets can be internet or unix sockets and have to be bound.
-    If the socket list is not empty, waitress creates one server for each socket.
-    Default is ``[]``.
+    .. versionadded:: 1.1.1
+        A list of sockets. The sockets can be internet or unix sockets and have to be bound.
+        If the socket list is not empty, waitress creates one server for each socket.
+        Default is ``[]``.
 
-    .. warning::
-        May not be used with ``listen``, ``host`` and/or ``port`` or ``unix_socket``
+        .. warning::
+            May not be used with ``listen``, ``host`` and/or ``port`` or ``unix_socket``
 
 threads
     number of threads used to process application logic (integer), default

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -51,6 +51,14 @@ unix_socket_perms
     Octal permissions to use for the Unix domain socket (string), default is
     ``600``. Only used if ``unix_socket`` is not ``None``.
 
+sockets
+    A list of sockets. The sockets can be internet or unix sockets and have to be bound.
+    If the socket list is not empty waitress creates one server for each socket.
+    Default is ``[]``.
+
+    .. warning::
+        May not be used with ``listen``, ``host`` and/or ``port`` or ``unix_socket``
+
 threads
     number of threads used to process application logic (integer), default
     ``4``

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -53,12 +53,12 @@ unix_socket_perms
 
 sockets
     .. versionadded:: 1.1.1
-        A list of sockets. The sockets can be internet or unix sockets and have to be bound.
+        A list of sockets. The sockets can be Internet or UNIX sockets and have to be bound.
         If the socket list is not empty, waitress creates one server for each socket.
         Default is ``[]``.
 
         .. warning::
-            May not be used with ``listen``, ``host`` and/or ``port`` or ``unix_socket``
+            May not be used with ``listen``, ``host``, ``port`` or ``unix_socket``
 
 threads
     number of threads used to process application logic (integer), default

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -53,7 +53,8 @@ unix_socket_perms
 
 sockets
     .. versionadded:: 1.1.1
-        A list of sockets. The sockets can be Internet or UNIX sockets and have to be bound.
+        A list of sockets. The sockets can be either Internet or UNIX sockets and have
+        to be bound. Internet and UNIX sockets cannot be mixed.
         If the socket list is not empty, waitress creates one server for each socket.
         Default is ``[]``.
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -53,7 +53,7 @@ unix_socket_perms
 
 sockets
     A list of sockets. The sockets can be internet or unix sockets and have to be bound.
-    If the socket list is not empty waitress creates one server for each socket.
+    If the socket list is not empty, waitress creates one server for each socket.
     Default is ``[]``.
 
     .. warning::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Extended Documentation
    arguments
    filewrapper
    runner
+   socket-activation
    glossary
 
 Change History

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -6,7 +6,7 @@ for example using systemd or launchd, it is prepared to receive pre-bound socket
 from init systems, process and socket managers or other launchers that can provide
 pre-bound sockets.
 
-The following shows a code example starting waitress with three different
+The following shows a code example starting waitress with two Internet sockets
 pre-bound sockets.
 
 .. code-block:: python
@@ -31,11 +31,9 @@ pre-bound sockets.
     if __name__ == '__main__':
         sockets = [
             socket.socket(socket.AF_INET, socket.SOCK_STREAM),
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM),
-            socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)]
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
         sockets[0].bind(('127.0.0.1', 8080))
         sockets[1].bind(('127.0.0.1', 9090))
-        sockets[2].bind('./test_socket')
         waitress.serve(app, sockets=sockets)
         for socket in sockets:
             socket.close()

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -2,10 +2,10 @@ Socket Activation
 -----------------
 
 While waitress does not support the various implementations of socket activation,
-e.g. using systemd or launchd, it is prepared to receive pre-bound applications
+for example using systemd or launchd, it is prepared to receive pre-bound applications
 from an init system.
 
-The following shows a code example starting waitress with three different,
+The following shows a code example starting waitress with three different
 pre-bound sockets.
 
 .. code-block:: python
@@ -41,7 +41,7 @@ pre-bound sockets.
 
 Generally, to implement socket activation for a given init system, a wrapper
 script uses the init system specific libraries to retrieve the sockets from
-the init system. Afterwards it starts waitress passing the sockets with the parameter
+the init system. Afterwards it starts waitress, passing the sockets with the parameter
 ``sockets``. Note that the sockets have to be bound, which all init systems
 supporting socket activation do.
 

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -2,8 +2,9 @@ Socket Activation
 -----------------
 
 While waitress does not support the various implementations of socket activation,
-for example using systemd or launchd, it is prepared to receive pre-bound applications
-from an init system.
+for example using systemd or launchd, it is prepared to receive pre-bound sockets
+from init systems, process and socket managers or other launchers that can provide
+pre-bound sockets.
 
 The following shows a code example starting waitress with three different
 pre-bound sockets.

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -41,7 +41,7 @@ pre-bound sockets.
 
 Generally, to implement socket activation for a given init system, a wrapper
 script uses the init system specific libraries to retrieve the sockets from
-the init system and the starts waitress passing the sockets using the parameter
+the init system. Afterwards it starts waitress passing the sockets with the parameter
 ``sockets``. Note that the sockets have to be bound, which all init systems
 supporting socket activation do.
 

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -1,0 +1,47 @@
+Socket Activation
+-----------------
+
+While waitress does not support the various implementations of socket activation,
+e.g. using systemd or launchd, it is prepared to receive pre-bound applications
+from an init system.
+
+The following shows a code example starting waitress with three different,
+pre-bound sockets.
+
+.. code-block:: python
+
+    import socket
+    import waitress
+
+
+    def app(environ, start_response):
+        content_length = environ.get('CONTENT_LENGTH', None)
+        if content_length is not None:
+            content_length = int(content_length)
+        body = environ['wsgi.input'].read(content_length)
+        content_length = str(len(body))
+        start_response(
+            '200 OK',
+            [('Content-Length', content_length), ('Content-Type', 'text/plain')]
+        )
+        return [body]
+
+
+    if __name__ == '__main__':
+        sockets = [
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+            socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)]
+        sockets[0].bind(('127.0.0.1', 8080))
+        sockets[1].bind(('127.0.0.1', 9090))
+        sockets[2].bind('./test_socket')
+        waitress.serve(app, sockets=sockets, bind_sockets=False)
+        for socket in sockets:
+            socket.close()
+
+Generally, to implement socket activation for a given init system, a wrapper
+script uses the init system specific libraries to retrieve the sockets from
+the init system and the starts waitress passing the sockets using the parameter
+``sockets``. Note that the sockets have to be bound, which all init systems
+supporting socket activation do.
+

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -35,7 +35,7 @@ pre-bound sockets.
         sockets[0].bind(('127.0.0.1', 8080))
         sockets[1].bind(('127.0.0.1', 9090))
         sockets[2].bind('./test_socket')
-        waitress.serve(app, sockets=sockets, bind_sockets=False)
+        waitress.serve(app, sockets=sockets)
         for socket in sockets:
             socket.close()
 

--- a/docs/socket-activation.rst
+++ b/docs/socket-activation.rst
@@ -3,11 +3,10 @@ Socket Activation
 
 While waitress does not support the various implementations of socket activation,
 for example using systemd or launchd, it is prepared to receive pre-bound sockets
-from init systems, process and socket managers or other launchers that can provide
+from init systems, process and socket managers, or other launchers that can provide
 pre-bound sockets.
 
-The following shows a code example starting waitress with two Internet sockets
-pre-bound sockets.
+The following shows a code example starting waitress with two Internet sockets pre-bound sockets.
 
 .. code-block:: python
 

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -237,6 +237,9 @@ class Adjustments(object):
         if 'sockets' in kw and ('host' in kw or 'port' in kw):
             raise ValueError('host and or port may not be set if sockets is set.')
 
+        if 'sockets' in kw and 'unix_socket' in kw:
+            raise ValueError('unix_socket may not be set if sockets is set')
+
         for k, v in kw.items():
             if k not in self._param_map:
                 raise ValueError('Unknown adjustment %r' % k)

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -235,7 +235,7 @@ class Adjustments(object):
             raise ValueError('socket may not be set if listen is set.')
 
         if 'sockets' in kw and ('host' in kw or 'port' in kw):
-            raise ValueError('host and or port may not be set if sockets is set.')
+            raise ValueError('host or port may not be set if sockets is set.')
 
         if 'sockets' in kw and 'unix_socket' in kw:
             raise ValueError('unix_socket may not be set if sockets is set')

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -378,7 +378,9 @@ class Adjustments(object):
             if (sock.family == socket.AF_INET or sock.family == socket.AF_INET6) and \
                     sock.type == socket.SOCK_STREAM:
                 has_inet_socket = True
-            elif sock.family == socket.AF_UNIX and sock.type == socket.SOCK_STREAM:
+            elif hasattr(socket, 'AF_UNIX') and \
+                    sock.family == socket.AF_UNIX and \
+                    sock.type == socket.SOCK_STREAM:
                 has_unix_socket = True
             else:
                 has_unsupported_socket = True

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -240,6 +240,12 @@ class Adjustments(object):
         if 'sockets' in kw and 'unix_socket' in kw:
             raise ValueError('unix_socket may not be set if sockets is set')
 
+        if 'unix_socket' in kw and ('host' in kw or 'port' in kw):
+            raise ValueError('unix_socket may not be set if host or port is set')
+
+        if 'unix_socket' in kw and 'listen' in kw:
+            raise ValueError('unix_socket may not be set if listen is set')
+
         for k, v in kw.items():
             if k not in self._param_map:
                 raise ValueError('Unknown adjustment %r' % k)

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -112,7 +112,6 @@ class Adjustments(object):
         ('unix_socket', str),
         ('unix_socket_perms', asoctal),
         ('sockets', as_socket_list),
-        ('bind_sockets', asbool),
     )
 
     _param_map = dict(_params)
@@ -227,10 +226,6 @@ class Adjustments(object):
     # be used for e.g. socket activation
     sockets = []
 
-    # Enable binding to sockets by default. This can be turned off for sockets
-    # that are supplied from the outside, e.g. using socket activation
-    bind_sockets = True
-
     def __init__(self, **kw):
 
         if 'listen' in kw and ('host' in kw or 'port' in kw):
@@ -241,9 +236,6 @@ class Adjustments(object):
 
         if 'sockets' in kw and ('host' in kw or 'port' in kw):
             raise ValueError('host and or port may not be set if sockets is set.')
-
-        if 'sockets' in kw and ('bind_sockets' not in kw or kw['bind_sockets']):
-            raise ValueError('Sockets passed should be bound already, please turn bind of with bind_sockets=False')
 
         for k, v in kw.items():
             if k not in self._param_map:

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -326,6 +326,8 @@ class Adjustments(object):
 
         self.listen = wanted_sockets
 
+        self.check_sockets(self.sockets)
+
     @classmethod
     def parse_args(cls, argv):
         """Pre-parse command line arguments for input into __init__.  Note that
@@ -366,3 +368,21 @@ class Adjustments(object):
                 kw[param] = value
 
         return kw, args
+
+    @classmethod
+    def check_sockets(cls, sockets):
+        has_unix_socket = False
+        has_inet_socket = False
+        has_unsupported_socket = False
+        for sock in sockets:
+            if (sock.family == socket.AF_INET or sock.family == socket.AF_INET6) and \
+                    sock.type == socket.SOCK_STREAM:
+                has_inet_socket = True
+            elif sock.family == socket.AF_UNIX and sock.type == socket.SOCK_STREAM:
+                has_unix_socket = True
+            else:
+                has_unsupported_socket = True
+        if has_unix_socket and has_inet_socket:
+            raise ValueError('Internet and UNIX sockets may not be mixed.')
+        if has_unsupported_socket:
+            raise ValueError('Only Internet or UNIX stream sockets may be used.')

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -229,7 +229,7 @@ class Adjustments(object):
     def __init__(self, **kw):
 
         if 'listen' in kw and ('host' in kw or 'port' in kw):
-            raise ValueError('host and or port may not be set if listen is set.')
+            raise ValueError('host or port may not be set if listen is set.')
 
         if 'listen' in kw and 'sockets' in kw:
             raise ValueError('socket may not be set if listen is set.')

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -71,7 +71,7 @@ def str_iftruthy(s):
 
 def as_socket_list(sockets):
     """Checks if the elements in the list are of type socket and
-    returns None if not."""
+    removes them if not."""
     return [sock for sock in sockets if isinstance(sock, socket.socket)]
 
 class _str_marker(str):

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -85,8 +85,8 @@ def create_server(application,
             effective_listen.append((last_serv.effective_host, last_serv.effective_port))
 
     for sock in adj.sockets:
+        sockinfo = (sock.family, sock.type, sock.proto, sock.getsockname())
         if sock.family == socket.AF_INET or sock.family == socket.AF_INET6:
-            sockinfo = (sock.family, sock.type, sock.proto, sock.getsockname())
             last_serv = TcpWSGIServer(
                 application,
                 map,
@@ -94,6 +94,7 @@ def create_server(application,
                 sock,
                 dispatcher=dispatcher,
                 adj=adj,
+                bind_socket=False,
                 sockinfo=sockinfo)
             effective_listen.append((last_serv.effective_host, last_serv.effective_port))
         elif hasattr(socket, 'AF_UNIX') and sock.family == socket.AF_UNIX:
@@ -104,7 +105,8 @@ def create_server(application,
                 sock,
                 dispatcher=dispatcher,
                 adj=adj,
-                sockinfo=(sock.family, sock.type, sock.proto, sock.getsockname()))
+                bind_socket=False,
+                sockinfo=sockinfo)
             effective_listen.append((last_serv.effective_host, last_serv.effective_port))
 
     # We are running a single server, so we can just return the last server,
@@ -175,6 +177,7 @@ class BaseWSGIServer(wasyncore.dispatcher, object):
                  dispatcher=None,  # dispatcher
                  adj=None,         # adjustments
                  sockinfo=None,    # opaque object
+                 bind_socket=True,
                  **kw
                  ):
         if adj is None:
@@ -206,7 +209,7 @@ class BaseWSGIServer(wasyncore.dispatcher, object):
 
         self.set_reuse_addr()
 
-        if adj.bind_sockets:
+        if bind_socket:
             self.bind_server_socket()
 
         self.effective_host, self.effective_port = self.getsockname()

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -255,21 +255,7 @@ class BaseWSGIServer(wasyncore.dispatcher, object):
         return server_name
 
     def getsockname(self):
-        try:
-            return self.socketmod.getnameinfo(
-                self.socket.getsockname(),
-                self.socketmod.NI_NUMERICSERV
-            )
-        except: # pragma: no cover
-            # This only happens on Linux because a DNS issue is considered a
-            # temporary failure that will raise (even when NI_NAMEREQD is not
-            # set). Instead we try again, but this time we just ask for the
-            # numerichost and the numericserv (port) and return those. It is
-            # better than nothing.
-            return self.socketmod.getnameinfo(
-                self.socket.getsockname(),
-                self.socketmod.NI_NUMERICHOST | self.socketmod.NI_NUMERICSERV
-            )
+        raise NotImplementedError # pragma: no cover
 
     def accept_connections(self):
         self.accepting = True
@@ -356,6 +342,23 @@ class TcpWSGIServer(BaseWSGIServer):
     def bind_server_socket(self):
         (_, _, _, sockaddr) = self.sockinfo
         self.bind(sockaddr)
+
+    def getsockname(self):
+        try:
+            return self.socketmod.getnameinfo(
+                self.socket.getsockname(),
+                self.socketmod.NI_NUMERICSERV
+            )
+        except: # pragma: no cover
+            # This only happens on Linux because a DNS issue is considered a
+            # temporary failure that will raise (even when NI_NAMEREQD is not
+            # set). Instead we try again, but this time we just ask for the
+            # numerichost and the numericserv (port) and return those. It is
+            # better than nothing.
+            return self.socketmod.getnameinfo(
+                self.socket.getsockname(),
+                self.socketmod.NI_NUMERICHOST | self.socketmod.NI_NUMERICSERV
+            )
 
     def set_socket_options(self, conn):
         for (level, optname, value) in self.adj.socket_options:

--- a/waitress/server.py
+++ b/waitress/server.py
@@ -111,7 +111,7 @@ def create_server(application,
 
     # We are running a single server, so we can just return the last server,
     # saves us from having to create one more object
-    if len(adj.listen) == 1 and len(adj.sockets) == 0 or len(adj.sockets) == 1:
+    if len(effective_listen) == 1:
         # In this case we have no need to use a MultiSocketServer
         return last_serv
 

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -56,7 +56,7 @@ class Test_as_socket_list(unittest.TestCase):
         sockets = [
             socket.socket(socket.AF_INET, socket.SOCK_STREAM),
             socket.socket(socket.AF_INET6, socket.SOCK_STREAM)]
-        if hasattr(sockets, 'AF_UNIX'):
+        if hasattr(socket, 'AF_UNIX'):
             sockets.append(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM))
         new_sockets = as_socket_list(sockets)
         self.assertEqual(sockets, new_sockets)

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -239,20 +239,8 @@ class TestAdjustments(unittest.TestCase):
         sockets = [
             socket.socket(socket.AF_INET6, socket.SOCK_STREAM),
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
-        inst = self._makeOne(sockets=sockets, bind_sockets=False)
+        inst = self._makeOne(sockets=sockets)
         self.assertEqual(inst.sockets, sockets)
-        sockets[0].close()
-        sockets[1].close()
-
-    def test_dont_use_sockets_with_bind_enabled(self):
-        sockets = [
-            socket.socket(socket.AF_INET6, socket.SOCK_STREAM),
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
-        self.assertRaises(
-            ValueError,
-            self._makeOne,
-            sockets=sockets,
-            bind_sockets=True)
         sockets[0].close()
         sockets[1].close()
 
@@ -274,14 +262,6 @@ class TestAdjustments(unittest.TestCase):
             port='8080',
             sockets=sockets)
         sockets[0].close()
-
-    def test_default_bind_sockets(self):
-        inst = self._makeOne()
-        self.assertEqual(inst.bind_sockets, True)
-
-    def test_good_bind_sockets(self):
-        inst = self._makeOne(bind_sockets=False)
-        self.assertEqual(inst.bind_sockets, False)
 
     def test_badvar(self):
         self.assertRaises(ValueError, self._makeOne, nope=True)

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -263,6 +263,15 @@ class TestAdjustments(unittest.TestCase):
             sockets=sockets)
         sockets[0].close()
 
+    def test_dont_mix_sockets_and_unix_socket(self):
+        sockets = [socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
+        self.assertRaises(
+            ValueError,
+            self._makeOne,
+            unix_socket='./tmp',
+            sockets=sockets)
+        sockets[0].close()
+
     def test_badvar(self):
         self.assertRaises(ValueError, self._makeOne, nope=True)
 

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -124,7 +124,6 @@ class TestAdjustments(unittest.TestCase):
             ident='abc',
             asyncore_loop_timeout='5',
             asyncore_use_poll=True,
-            unix_socket='/tmp/waitress.sock',
             unix_socket_perms='777',
             url_prefix='///foo/',
             ipv4=True,
@@ -151,7 +150,6 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.asyncore_loop_timeout, 5)
         self.assertEqual(inst.asyncore_use_poll, True)
         self.assertEqual(inst.ident, 'abc')
-        self.assertEqual(inst.unix_socket, '/tmp/waitress.sock')
         self.assertEqual(inst.unix_socket_perms, 0o777)
         self.assertEqual(inst.url_prefix, '/foo')
         self.assertEqual(inst.ipv4, True)
@@ -268,9 +266,24 @@ class TestAdjustments(unittest.TestCase):
         self.assertRaises(
             ValueError,
             self._makeOne,
-            unix_socket='./tmp',
+            unix_socket='./tmp/test',
             sockets=sockets)
         sockets[0].close()
+
+    def test_dont_mix_unix_socket_and_host_port(self):
+        self.assertRaises(
+            ValueError,
+            self._makeOne,
+            unix_socket='./tmp/test',
+            host='localhost',
+            port='8080')
+
+    def test_dont_mix_unix_socket_and_listen(self):
+        self.assertRaises(
+            ValueError,
+            self._makeOne,
+            unix_socket='./tmp/test',
+            listen='127.0.0.1:8080')
 
     def test_badvar(self):
         self.assertRaises(ValueError, self._makeOne, nope=True)

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -373,12 +373,12 @@ if hasattr(socket, 'AF_UNIX'):
                                         TcpWSGIServer, UnixWSGIServer
             sockets = [
                 socket.socket(socket.AF_UNIX, socket.SOCK_STREAM),
-                socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
+                socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)]
             inst = self._makeWithSockets(sockets=sockets, _start=False)
             self.assertTrue(isinstance(inst, MultiSocketServer))
             server = list(filter(lambda s: isinstance(s, BaseWSGIServer), inst.map.values()))
             self.assertTrue(isinstance(server[0], UnixWSGIServer))
-            self.assertTrue(isinstance(server[1], TcpWSGIServer))
+            self.assertTrue(isinstance(server[1], UnixWSGIServer))
 
 
 class DummySock(socket.socket):

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -62,7 +62,6 @@ class TestWSGIServer(unittest.TestCase):
             _dispatcher=_dispatcher,
             _start=_start,
             _sock=_sock,
-            bind_sockets=False,
             sockets=_sockets)
         return self.inst
 
@@ -321,7 +320,6 @@ if hasattr(socket, 'AF_UNIX'):
                 _dispatcher=_dispatcher,
                 _start=_start,
                 _sock=_sock,
-                bind_sockets=False,
                 sockets=_sockets)
             return self.inst
 

--- a/waitress/tests/test_server.py
+++ b/waitress/tests/test_server.py
@@ -255,6 +255,7 @@ class TestWSGIServer(unittest.TestCase):
     def test_create_with_one_tcp_socket(self):
         from waitress.server import TcpWSGIServer
         sockets = [socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
+        sockets[0].bind(('127.0.0.1', 0))
         inst = self._makeWithSockets(_start=False, sockets=sockets)
         self.assertTrue(isinstance(inst, TcpWSGIServer))
 
@@ -262,7 +263,9 @@ class TestWSGIServer(unittest.TestCase):
         from waitress.server import MultiSocketServer
         sockets = [
             socket.socket(socket.AF_INET, socket.SOCK_STREAM),
-            socket.socket(socket.AF_INET6, socket.SOCK_STREAM)]
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
+        sockets[0].bind(('127.0.0.1', 0))
+        sockets[1].bind(('127.0.0.1', 0))
         inst = self._makeWithSockets(_start=False, sockets=sockets)
         self.assertTrue(isinstance(inst, MultiSocketServer))
         self.assertEqual(len(inst.effective_listen), 2)


### PR DESCRIPTION
As discussed in issue #204, the pull request adds the new parameter `sockets` to `serve` and `create_server` which can be used to create waitress instances using already existing and bound sockets, e.g. for socket activation with *systemd* or *launchd*.

The changes are tested with several additional test cases.

In addition to the code changes, it adds a new page to the documentation and a new entry to describe the new parameter `sockets` in the page for arguments. Adding the entry in arguments is done under the assumption that the next version will be **1.1.1** to supply the version number for `versionadded`.

The changes only add the parameter, they do not handle init system specific tasks like creating sockets from file descriptors because we want to avoid dependencies to init systems.

Closes #204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pylons/waitress/215)
<!-- Reviewable:end -->
