### PR TITLE
Fix error when HTTP version is missing in Python 3

### DIFF
--- a/waitress/compat.py
+++ b/waitress/compat.py
@@ -54,6 +54,8 @@ def text_(s, encoding='latin-1', errors='strict'):
 
 if PY3: # pragma: no cover
     def tostr(s):
+        if s is None:
+            return 'None'
         if isinstance(s, text_type):
             s = s.encode('latin-1')
         return str(s, 'latin-1', 'strict')


### PR DESCRIPTION
I encountered the following error in the log of our web server running waitress 1.1.0 on Python 3.6.1:

> uncaptured python exception, closing channel <waitress.channel.HTTPChannel connected 140.10.xxx.xxx:37060 at 0x17ed609aa90> (<class 'TypeError'>:decoding to str: need a bytes-like object, NoneType found [asyncore.py|read|83] [asyncore.py|handle_read_event|423] [lib\site-packages\waitress\channel.py|handle_read|174] [lib\site-packages\waitress\channel.py|received|191] [lib\site-packages\waitress\parser.py|received|102] [lib\site-packages\waitress\parser.py|parse_header|201] [lib\site-packages\waitress\compat.py|tostr|53])

The problem comes from the variable `version` being set to `None` if it is missing in the request and being transformed to a string afterwards.
https://github.com/Pylons/waitress/blob/77bb0026eebaa94845cc1a967171ca2f3e3fdfe0/waitress/parser.py#L296
https://github.com/Pylons/waitress/blob/77bb0026eebaa94845cc1a967171ca2f3e3fdfe0/waitress/parser.py#L201

The suggested fix improves the Python 3 compatibility function to handle `None` values the same way as Python 2 does. Another fix would be of course to not try to convert `None` to a string in the first place.