### PR TITLE
added any as valid value for the trusted_proxy adjustable

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -791,7 +791,7 @@ class WSGITask(Task):
         headers = dict(request.headers)
 
         untrusted_headers = PROXY_HEADERS
-        if remote_peer == server.adj.trusted_proxy:
+        if server.adj.trusted_proxy == 'any' or remote_peer == server.adj.trusted_proxy:
             untrusted_headers = self.parse_proxy_headers(
                 environ,
                 headers,

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -791,7 +791,7 @@ class WSGITask(Task):
         headers = dict(request.headers)
 
         untrusted_headers = PROXY_HEADERS
-        if server.adj.trusted_proxy == 'any' or remote_peer == server.adj.trusted_proxy:
+        if server.adj.trusted_proxy == '*' or remote_peer == server.adj.trusted_proxy:
             untrusted_headers = self.parse_proxy_headers(
                 environ,
                 headers,


### PR DESCRIPTION
Backgound is when waitress is running inside a container, any
request is originates from the gateway of the container network, not
from the outside ip. The container network changes every time the
container is restarted to a random new network number. So setting one
IP as trusted_proxy isn't possible but still needed as most of the time
an reverse proxy is between the client an the container. So if it's
ensured that only requests from the reverse proxy can reach the
container, trusting any host is not a problem.