### PR TITLE
Fix/remote addr

### DIFF
--- a/waitress/task.py
+++ b/waitress/task.py
@@ -535,9 +535,13 @@ class WSGITask(Task):
                 forward_hop = forward_hop.strip()
                 forward_hop = undquote(forward_hop)
 
-                # Make sure that all IPv6 addresses are surrounded by brackets
+                # Make sure that all IPv6 addresses are surrounded by brackets,
+                # this is assuming that the IPv6 representation here does not
+                # include a port number.
 
-                if ":" in forward_hop and forward_hop[-1] != "]":
+                if "." not in forward_hop and (
+                    ":" in forward_hop and forward_hop[-1] != "]"
+                ):
                     forwarded_for.append("[{}]".format(forward_hop))
                 else:
                     forwarded_for.append(forward_hop)

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -722,12 +722,17 @@ class WSGITask(Task):
             environ["SERVER_PORT"] = str(forwarded_port)
 
         if client_addr:
+            def strip_brackets(addr):
+                if addr[0] == "[" and addr[-1] == "]":
+                    return addr[1:-1]
+                return addr
+
             if ":" in client_addr and client_addr[-1] != "]":
                 addr, port = client_addr.rsplit(":", 1)
-                environ["REMOTE_ADDR"] = addr.strip()
+                environ["REMOTE_ADDR"] = strip_brackets(addr.strip())
                 environ["REMOTE_PORT"] = port.strip()
             else:
-                environ["REMOTE_ADDR"] = client_addr.strip()
+                environ["REMOTE_ADDR"] = strip_brackets(client_addr.strip())
 
         return untrusted_headers
 

--- a/waitress/tests/test_task.py
+++ b/waitress/tests/test_task.py
@@ -989,7 +989,7 @@ class TestWSGITask(unittest.TestCase):
             trusted_proxy_headers={'x-forwarded-for'}
         )
 
-        self.assertEqual(environ['REMOTE_ADDR'], '[2001:db8::0]')
+        self.assertEqual(environ['REMOTE_ADDR'], '2001:db8::0')
 
     def test_parse_proxy_headers_forwared_for_multiple(self):
         inst = self._makeOne()
@@ -1029,7 +1029,7 @@ class TestWSGITask(unittest.TestCase):
         inst = self._makeOne()
 
         headers = {
-            'FORWARDED': 'for="[2001:db8::1]";host="example.com:8443";proto="https", for=192.0.2.1;host="example.internal:8080"'
+            'FORWARDED': 'for="[2001:db8::1]:3821";host="example.com:8443";proto="https", for=192.0.2.1;host="example.internal:8080"'
         }
         environ = {}
         inst.parse_proxy_headers(
@@ -1039,7 +1039,8 @@ class TestWSGITask(unittest.TestCase):
             trusted_proxy_headers={'forwarded'}
         )
 
-        self.assertEqual(environ['REMOTE_ADDR'], '[2001:db8::1]')
+        self.assertEqual(environ['REMOTE_ADDR'], '2001:db8::1')
+        self.assertEqual(environ['REMOTE_PORT'], '3821')
         self.assertEqual(environ['SERVER_NAME'], 'example.com')
         self.assertEqual(environ['HTTP_HOST'], 'example.com:8443')
         self.assertEqual(environ['SERVER_PORT'], '8443')
@@ -1059,7 +1060,7 @@ class TestWSGITask(unittest.TestCase):
             trusted_proxy_headers={'forwarded'}
         )
 
-        self.assertEqual(environ['REMOTE_ADDR'], '[2001:db8::1]')
+        self.assertEqual(environ['REMOTE_ADDR'], '2001:db8::1')
         self.assertEqual(environ['SERVER_NAME'], 'example.org')
         self.assertEqual(environ['HTTP_HOST'], 'example.org')
         self.assertEqual(environ['SERVER_PORT'], '443')


### PR DESCRIPTION
`REMOTE_ADDR` is inherited from the CGI spec, and it specifies that IP addresses should be placed in `REMOTE_ADDR`, and while IPv6 formatting allows for using brackets around the IP address, it is only generally done when you are also including the port number.

The port number is in `REMOTE_PORT` (if it exists) and thus the formatting with a bracket is not correct.

Closes #230