### PR TITLE
use tox extras key for testing and add pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
           sudo: true
         - python: pypy
           env: TOXENV=pypy
+        - python: pypy3
+          env: TOXENV=pypy3
         - python: 3.5
-          env: TOXENV=py2-cover,py3-cover,coverage
+          env: TOXENV=py27-cover,py35-cover,coverage
         - python: 3.5
           env: TOXENV=docs
     allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,48 +1,40 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,
+    py27,py34,py35,py36,py37,pypy,pypy3,
     docs,
-    {py2,py3}-cover,coverage
+    {py27,py35}-cover,coverage
 
 [testenv]
-# Most of these are defaults but if you specify any you can't fall back
-# to defaults for others.
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    py38: python3.8
-    pypy: pypy
-    py2: python2.7
-    py3: python3.5
-
 commands =
-    pip install waitress[testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
+
+extras =
+    testing
 
 [testenv:docs]
 basepython = python3.5
 whitelist_externals = make
 commands =
-    pip install waitress[docs]
     make -C docs clean html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+extras =
+    docs
 
 [py-cover]
 commands =
-    pip install waitress[testing]
     coverage run --source=waitress --parallel-mode {envbindir}/nosetests
     coverage combine
     coverage xml -o {envname}.xml
 
-[testenv:py2-cover]
+extras =
+    testing
+
+[testenv:py27-cover]
 commands =
     {[py-cover]commands}
 setenv =
     COVERAGE_FILE=.coverage.py2
 
-[testenv:py3-cover]
+[testenv:py35-cover]
 commands =
     {[py-cover]commands}
 setenv =


### PR DESCRIPTION
This does change the coverage files to be named `py27-cover.xml` instead of `py2-cover.xml`, etc. Pointing that out incase something depends on it.