### PR TITLE
outbuf_high_watermark

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,15 @@ Deprecations
 Features
 ~~~~~~~~
 
+- Add a new ``outbuf_high_watermark`` adjustment which is used to apply
+  backpressure on the ``app_iter`` to avoid letting it spin faster than data
+  can be written to the socket. This stabilizes responses that iterate quickly
+  with a lot of data.
+  See https://github.com/Pylons/waitress/pull/242
+
+Bugfixes
+~~~~~~~~
+
 - Stop early and close the ``app_iter`` when attempting to write to a closed
   socket due to a client disconnect. This should notify a long-lived streaming
   response when a client hangs up.
@@ -26,9 +35,6 @@ Features
   still be flushed efficiently.
   See https://github.com/Pylons/waitress/pull/246
 
-Bugfixes
-~~~~~~~~
-
 - When a client closes a socket unexpectedly there was potential for memory
   leaks in which data was written to the buffers after they were closed,
   causing them to reopen.
@@ -42,6 +48,12 @@ Bugfixes
   noticeable for users of the internal server api. In more typical operations
   the server will die before benefiting from these changes.
   See https://github.com/Pylons/waitress/pull/245
+
+- Fix a bug in which an ``app_iter`` that emits data chunks quicker than can
+  be written to a socket may never cleanup data that has already been sent.
+  This would cause buffers in waitress to grow without bounds. These buffers
+  now properly reclaim their space as data is written to the socket.
+  See https://github.com/Pylons/waitress/pull/242
 
 1.2.1 (2019-01-25)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,9 +17,6 @@ Features
   with a lot of data.
   See https://github.com/Pylons/waitress/pull/242
 
-Bugfixes
-~~~~~~~~
-
 - Stop early and close the ``app_iter`` when attempting to write to a closed
   socket due to a client disconnect. This should notify a long-lived streaming
   response when a client hangs up.
@@ -35,6 +32,9 @@ Bugfixes
   still be flushed efficiently.
   See https://github.com/Pylons/waitress/pull/246
 
+Bugfixes
+~~~~~~~~
+
 - When a client closes a socket unexpectedly there was potential for memory
   leaks in which data was written to the buffers after they were closed,
   causing them to reopen.
@@ -49,10 +49,9 @@ Bugfixes
   the server will die before benefiting from these changes.
   See https://github.com/Pylons/waitress/pull/245
 
-- Fix a bug in which an ``app_iter`` that emits data chunks quicker than can
-  be written to a socket may never cleanup data that has already been sent.
-  This would cause buffers in waitress to grow without bounds. These buffers
-  now properly reclaim their space as data is written to the socket.
+- Fix a bug in which a streaming ``app_iter`` may never cleanup data that has
+  already been sent. This would cause buffers in waitress to grow without
+  bounds. These buffers now properly rotate and release their data.
   See https://github.com/Pylons/waitress/pull/242
 
 1.2.1 (2019-01-25)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,6 @@
 
 .. module:: waitress
 
-.. function:: serve(app, listen='0.0.0.0:8080', unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', url_prefix='', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=1, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
+.. function:: serve(app, listen='0.0.0.0:8080', unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', url_prefix='', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=1, outbuf_overflow=104856, outbuf_high_watermark=16777216, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
 
      See :ref:`arguments` for more information.

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -200,6 +200,13 @@ outbuf_overflow
 
     Default: ``1048576`` (1MB)
 
+outbuf_high_watermark
+    The app_iter will pause when pending output is larger than this value
+    and will resume once enough data is written to the socket to fall below
+    this threshold.
+
+    Default: ``16777216`` (16MB)
+
 inbuf_overflow
     A tempfile should be created if the pending input is larger than
     inbuf_overflow, which is measured in bytes. The default is conservative.

--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -152,6 +152,11 @@ Tuning options:
     A temporary file should be created if the pending output is larger than
     this. Default is 1048576 (1MB).
 
+``--outbuf-high-watermark=INT``
+    The app_iter will pause when pending output is larger than this value
+    and will resume once enough data is written to the socket to fall below
+    this threshold. Default is 16777216 (16MB).
+
 ``--inbuf-overflow=INT``
     A temporary file should be created if the pending input is larger than
     this. Default is 524288 (512KB).

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -112,6 +112,7 @@ class Adjustments(object):
         ('recv_bytes', int),
         ('send_bytes', int),
         ('outbuf_overflow', int),
+        ('outbuf_high_watermark', int),
         ('inbuf_overflow', int),
         ('connection_limit', int),
         ('cleanup_interval', int),
@@ -203,6 +204,10 @@ class Adjustments(object):
     # outbuf_overflow, which is measured in bytes. The default is 1MB.  This
     # is conservative.
     outbuf_overflow = 1048576
+
+    # The app_iter will pause when pending output is larger than this value
+    # in bytes.
+    outbuf_high_watermark = 16777216
 
     # A tempfile should be created if the pending input is larger than
     # inbuf_overflow, which is measured in bytes. The default is 512K.  This

--- a/waitress/channel.py
+++ b/waitress/channel.py
@@ -222,7 +222,7 @@ class HTTPChannel(wasyncore.dispatcher, object):
         while True:
             outbuf = self.outbufs[0]
             # use outbuf.__len__ rather than len(outbuf) FBO of not getting
-            # OverflowError on Python 2
+             # OverflowError on 32-bit Python
             outbuflen = outbuf.__len__()
             while outbuflen > 0:
                 chunk = outbuf.get(self.sendbuf_len)

--- a/waitress/channel.py
+++ b/waitress/channel.py
@@ -313,9 +313,9 @@ class HTTPChannel(wasyncore.dispatcher, object):
                     self.outbufs.append(nextbuf)
                     self.current_outbuf_count = 0
                 else:
-                    # if we overflowed then start a new buffer to ensure avoid
-                    # this buffer growing unbounded
                     if self.current_outbuf_count > self.adj.outbuf_high_watermark:
+                        # rotate to a new buffer if the current buffer has hit
+                        # the watermark to avoid it growing unbounded
                         nextbuf = OverflowableBuffer(self.adj.outbuf_overflow)
                         self.outbufs.append(nextbuf)
                         self.current_outbuf_count = 0

--- a/waitress/runner.py
+++ b/waitress/runner.py
@@ -126,6 +126,11 @@ Tuning options:
         A temporary file should be created if the pending output is larger
         than this. Default is 1048576 (1MB).
 
+    --outbuf-high-watermark=INT
+        The app_iter will pause when pending output is larger than this value
+        and will resume once enough data is written to the socket to fall below
+        this threshold. Default is 16777216 (16MB).
+
     --inbuf-overflow=INT
         A temporary file should be created if the pending input is larger
         than this. Default is 524288 (512KB).


### PR DESCRIPTION
Fixes https://github.com/Pylons/waitress/issues/67.

The `outbuf_high_watermark` is a setting that can be used to apply backpressure on the `app_iter` if it is yielding data faster than can be written to the client. When the socket falls behind, the `app_iter` will not resume until the socket catches up to at least the watermark (this does not mean the socket is caught up, just that it's not so far behind).