### PR TITLE
flush SO_SNDBUF data on every send and deprecate send_bytes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,14 @@
 unreleased
 ----------
 
-Bugfixes
+Deprecations
+~~~~~~~~~~~~
+
+- The ``send_bytes`` adjustment now defaults to ``1`` and is deprecated
+  pending removal in a future release.
+  and https://github.com/Pylons/waitress/pull/246
+
+Features
 ~~~~~~~~
 
 - Stop early and close the ``app_iter`` when attempting to write to a closed
@@ -10,6 +17,17 @@ Bugfixes
   See https://github.com/Pylons/waitress/pull/238
   and https://github.com/Pylons/waitress/pull/240
   and https://github.com/Pylons/waitress/pull/241
+
+- Adjust the flush to output ``SO_SNDBUF`` bytes instead of whatever was
+  set in the ``send_bytes`` adjustment. ``send_bytes`` now only controls how
+  much waitress will buffer internally before flushing to the kernel, whereas
+  previously it used to also throttle how much data was sent to the kernel.
+  This change enables a streaming ``app_iter`` containing small chunks to
+  still be flushed efficiently.
+  See https://github.com/Pylons/waitress/pull/246
+
+Bugfixes
+~~~~~~~~
 
 - When a client closes a socket unexpectedly there was potential for memory
   leaks in which data was written to the buffers after they were closed,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,6 @@
 
 .. module:: waitress
 
-.. function:: serve(app, listen='0.0.0.0:8080', unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', url_prefix='', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=18000, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
+.. function:: serve(app, listen='0.0.0.0:8080', unix_socket=None, unix_socket_perms='600', threads=4, url_scheme='http', url_prefix='', ident='waitress', backlog=1204, recv_bytes=8192, send_bytes=1, outbuf_overflow=104856, inbuf_overflow=52488, connection_limit=1000, cleanup_interval=30, channel_timeout=120, log_socket_errors=True, max_request_header_size=262144, max_request_body_size=1073741824, expose_tracebacks=False)
 
      See :ref:`arguments` for more information.

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -190,7 +190,9 @@ send_bytes
     Linux, ``/proc/sys/net/ipv4/tcp_wmem`` controls the minimum, default, and
     maximum sizes of TCP write buffers.
 
-    Default: ``18000``
+    Default: ``1``
+
+    .. deprecated:: 1.3
 
 outbuf_overflow
     A tempfile should be created if the pending output is larger than

--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -143,8 +143,10 @@ Tuning options:
     8192.
 
 ``--send-bytes=INT``
-    Number of bytes to send to socket.send(). Default is 18000.
+    Number of bytes to send to socket.send(). Default is 1.
     Multiples of 9000 should avoid partly-filled TCP packets.
+
+    .. deprecated:: 1.3
 
 ``--outbuf-overflow=INT``
     A temporary file should be created if the pending output is larger than

--- a/waitress/adjustments.py
+++ b/waitress/adjustments.py
@@ -195,11 +195,9 @@ class Adjustments(object):
     # recv_bytes is the argument to pass to socket.recv().
     recv_bytes = 8192
 
-    # send_bytes is the number of bytes to send to socket.send().  Multiples
-    # of 9000 should avoid partly-filled packets, but don't set this larger
-    # than the TCP write buffer size.  In Linux, /proc/sys/net/ipv4/tcp_wmem
-    # controls the minimum, default, and maximum sizes of TCP write buffers.
-    send_bytes = 18000
+    # deprecated setting controls how many bytes will be buffered before
+    # being flushed to the socket
+    send_bytes = 1
 
     # A tempfile should be created if the pending output is larger than
     # outbuf_overflow, which is measured in bytes. The default is 1MB.  This
@@ -288,6 +286,12 @@ class Adjustments(object):
 
         if 'unix_socket' in kw and 'listen' in kw:
             raise ValueError('unix_socket may not be set if listen is set')
+
+        if 'send_bytes' in kw:
+            warnings.warn(
+                'send_bytes will be removed in a future release',
+                DeprecationWarning,
+            )
 
         for k, v in kw.items():
             if k not in self._param_map:

--- a/waitress/tests/test_adjustments.py
+++ b/waitress/tests/test_adjustments.py
@@ -361,6 +361,16 @@ class TestAdjustments(unittest.TestCase):
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
             self.assertIn("clear_untrusted_proxy_headers will be set to True", str(w[0]))
 
+    def test_deprecated_send_bytes(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.resetwarnings()
+            warnings.simplefilter("always")
+            self._makeOne(send_bytes=1)
+
+            self.assertGreaterEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("send_bytes", str(w[0]))
+
     def test_badvar(self):
         self.assertRaises(ValueError, self._makeOne, nope=True)
 


### PR DESCRIPTION
Fixes https://github.com/Pylons/waitress/issues/120

Currently I deprecated `send_bytes` and it only affects the decision to flush but not how much to flush. Alternative options include:

1. Remove the setting entirely and emit an error.

2. Remove the setting but allow it and emit a `UserWarning` triggering people to remove it from their settings.

3. Do not deprecate the setting and just define it as only affecting when to flush but not how much. Change the default to 1.

I propose keeping it like I did in the PR and then removing it in waitress 2.0 along with the trusted proxy backward-incompatible changes.