### PR TITLE
warn if there are more pending jobs than idle threads

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,7 @@ Bugfixes
 
 - Fix the queue depth warnings to only show when all threads are busy.
   See https://github.com/Pylons/waitress/pull/243
+  and https://github.com/Pylons/waitress/pull/247
 
 - Trigger the ``app_iter`` to close as part of shutdown. This will only be
   noticeable for users of the internal server api. In more typical operations


### PR DESCRIPTION
Fixes comments in https://github.com/Pylons/waitress/pull/243#issuecomment-480302635.

1. A warning will now be emitted if a bunch of tasks are submitted while there is an idle thread, before the threads pop the jobs, because we know that when they pop them there will still be too many.
2. Greatly simplified the shutdown logic on the threads to use only `stop_count` and get rid of the tombstoned `None` task.
3. Shutdown now uses a condition to exit every so slightly faster when all threads are complete by having each dying thread notify.
4. Added a warning on shutdown if any tasks are canceled.