### PR TITLE
support non-seekable buffers

### DIFF
--- a/waitress/server.py
+++ b/waitress/server.py
@@ -349,7 +349,7 @@ class TcpWSGIServer(BaseWSGIServer):
                 self.socket.getsockname(),
                 self.socketmod.NI_NUMERICSERV
             )
-        except: # pragma: no cover
+        except Exception: # pragma: no cover
             # This only happens on Linux because a DNS issue is considered a
             # temporary failure that will raise (even when NI_NAMEREQD is not
             # set). Instead we try again, but this time we just ask for the

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -451,11 +451,11 @@ class WSGITask(Task):
             if app_iter.__class__ is ReadOnlyFileBasedBuffer:
                 cl = self.content_length
                 size = app_iter.prepare(cl)
-                if size:
-                    if cl != size:
-                        if cl is not None:
-                            self.remove_content_length_header()
-                        self.content_length = size
+                if size > 0 and cl != size:
+                    if cl is not None:
+                        self.remove_content_length_header()
+                    self.content_length = size
+                if size != 0:
                     self.write(b'') # generate headers
                     # if the write_soon below succeeds then the channel will
                     # take over closing the underlying file via the channel's

--- a/waitress/task.py
+++ b/waitress/task.py
@@ -404,7 +404,7 @@ class WSGITask(Task):
 
             self.complete = True
 
-            if not status.__class__ is str:
+            if status.__class__ is not str:
                 raise AssertionError('status %s is not a string' % status)
             if '\n' in status or '\r' in status:
                 raise ValueError("carriage return/line "
@@ -414,11 +414,11 @@ class WSGITask(Task):
 
             # Prepare the headers for output
             for k, v in headers:
-                if not k.__class__ is str:
+                if k.__class__ is not str:
                     raise AssertionError(
                         'Header name %r is not a string in %r' % (k, (k, v))
                     )
-                if not v.__class__ is str:
+                if v.__class__ is not str:
                     raise AssertionError(
                         'Header value %r is not a string in %r' % (v, (k, v))
                     )

--- a/waitress/tests/test_channel.py
+++ b/waitress/tests/test_channel.py
@@ -354,7 +354,7 @@ class TestHTTPChannel(unittest.TestCase):
                 self.length = MAXINT + 1
             def __len__(self):
                 return self.length
-            def get(self, numbytes):
+            def get(self, numbytes, *args):
                 self.length = 0
                 return b'123'
             def skip(self, *args): pass
@@ -754,15 +754,14 @@ class DummyBuffer(object):
         self.data = data
         self.toraise = toraise
 
-    def get(self, *arg):
+    def get(self, numbytes, skip=False):
         if self.toraise:
             raise self.toraise
-        data = self.data
-        self.data = b''
+        data = self.data[:numbytes]
+        if skip:
+            self.data = data[numbytes:]
+            self.skipped = len(data)
         return data
-
-    def skip(self, num, x):
-        self.skipped = num
 
     def __len__(self):
         return len(self.data)


### PR DESCRIPTION
fixes #84 

There's a lot going on here, but it's all in the name of 1) optimizing the buffer codebase and 2) supporting non-seekable ROFBB objects.

- Replaced `buffer.get()` and `buffer.skip()` with `buffer.read()` and `buffer.rollback()`. This optimizes the workflow around reading to normally not need to do any seeking.

- Deleted `buffer.prune()`.

- Track on a per-buffer basis whether it's seekable and if it's not seekable then instead of trying to put the data back into the buffer, make a small temporary `BytesIOBasedBuffer` with the data that didn't get sent.

- If an `OverflowableBuffer` reaches a file, keep it on a file to avoid oscillating between a file and a bytesio as data is written. The buffer is eventually rotated at the high watermark to reset the state.