### PR TITLE
avoid converting the version to a string value "None", empty instead

### DIFF
--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -293,7 +293,7 @@ def crack_first_line(line):
         if m.group(3):
             version = m.group(5)
         else:
-            version = None
+            version = b''
         method = m.group(1)
 
         # the request methods that are currently defined are all uppercase:

--- a/waitress/tests/test_parser.py
+++ b/waitress/tests/test_parser.py
@@ -309,9 +309,12 @@ class Test_crack_first_line(unittest.TestCase):
         result = self._callFUT(b'GET / bleh')
         self.assertEqual(result, (b'', b'', b''))
 
+        result = self._callFUT(b'GET /info?txtAirPlay&txtRAOP RTSP/1.0')
+        self.assertEqual(result, (b'', b'', b''))
+
     def test_crack_first_line_missing_version(self):
         result = self._callFUT(b'GET /')
-        self.assertEqual(result, (b'GET', b'/', None))
+        self.assertEqual(result, (b'GET', b'/', b''))
 
 class TestHTTPRequestParserIntegration(unittest.TestCase):
 


### PR DESCRIPTION
fixes #110
replaces #221 