### PR TITLE
Suppress duplicate messages

### DIFF
--- a/waitress/server.py
+++ b/waitress/server.py
@@ -139,7 +139,7 @@ class MultiSocketServer(object):
         self.task_dispatcher = dispatcher
 
     def print_listen(self, format_str): # pragma: nocover
-        for l in self.effective_listen:
+        for l in set(self.effective_listen):
             l = list(l)
 
             if ':' in l[0]:


### PR DESCRIPTION
If `waitress` is configured to listen to `127.0.0.1`, then one message appears as expected.
```
[server:main]
use = egg:waitress#main
listen = 127.0.0.1:5000
...
Starting server in PID 27772.
Serving on http://localhost:5000
```

However, if `waitress` is configured to listen to `localhost`, then two messages appear because `effective_listen` contains two duplicate tuples.
```[server:main]
use = egg:waitress#main
listen = localhost:5000
...
Starting server in PID 27772.
Serving on http://localhost:5000
Serving on http://localhost:5000
```

This commit suppresses duplicate messages.