### PR TITLE
Shut down gracefully on SIGTERM

### DIFF
--- a/waitress/server.py
+++ b/waitress/server.py
@@ -14,6 +14,7 @@
 
 import os
 import os.path
+import signal
 import socket
 import time
 
@@ -148,7 +149,11 @@ class MultiSocketServer(object):
 
             print(format_str.format(*l))
 
+    def handle_sigterm(self, signum, frame):
+        raise SystemExit
+
     def run(self):
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
         try:
             self.asyncore.loop(
                 timeout=self.adj.asyncore_loop_timeout,
@@ -315,7 +320,11 @@ class BaseWSGIServer(wasyncore.dispatcher, object):
         addr = self.fix_addr(addr)
         self.channel_class(self, conn, addr, self.adj, map=self._map)
 
+    def handle_sigterm(self, signum, frame):
+        raise SystemExit
+
     def run(self):
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
         try:
             self.asyncore.loop(
                 timeout=self.adj.asyncore_loop_timeout,


### PR DESCRIPTION
At the moment, Waitress handles `SIGINT` nicely enough (it waits 5 seconds for any existing requests to finish before exiting).

However, it doesn't handle `SIGTERM` - it just dies straight away. Heroku sends `SIGTERM` to processes when it is stopping a dyno, and indeed the [12 Factor methodology](https://12factor.net/disposability) specifically mentions `SIGTERM` as the signal that should be used to perform a graceful shutdown.

This PR adds a signal handler which just raises `SystemExit` when `SIGTERM` is received. This exception is caught by the existing `except` block around `asyncore.loop` which then calls `self.task_dispatcher.shutdown()`.

I really wasn't sure how to test this. I borrowed the threading idea from [this stackoverflow answer](https://stackoverflow.com/a/49615525) but it doesn't seem great. On the other hand, there don't seem to be any specific tests for the existing `SIGINT` behaviour (unless I've just missed them) so maybe this is overkill?