### PR TITLE
Drop Python 3.4

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -12,6 +12,7 @@ jobs:
                     {'py': '3.5', 'env': 'py35'},
                     {'py': '3.6', 'env': 'py36'},
                     {'py': '3.7', 'env': 'py37'},
+                    {'py': '3.8', 'env': 'py38'},
                     {'py': 'pypy2', 'env': 'pypy'},
                     {'py': 'pypy3', 'env': 'pypy3'}
                 ]

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -7,26 +7,26 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                tox: [
-                    {'py': '2.7', 'env': 'py27'},
-                    {'py': '3.5', 'env': 'py35'},
-                    {'py': '3.6', 'env': 'py36'},
-                    {'py': '3.7', 'env': 'py37'},
-                    {'py': '3.8', 'env': 'py38'},
-                    {'py': 'pypy2', 'env': 'pypy'},
-                    {'py': 'pypy3', 'env': 'pypy3'}
+                py: [
+                    '2.7',
+                    '3.5',
+                    '3.6',
+                    '3.7',
+                    '3.8',
+                    'pypy2',
+                    'pypy3'
                 ]
-        name: "Python: ${{ matrix.tox.py }}"
+        name: "Python: ${{ matrix.py }}"
         steps:
             - uses: actions/checkout@master
             - name: Setup python
               uses: actions/setup-python@v1
               with:
-                  python-version: ${{ matrix.tox.py }}
+                  python-version: ${{ matrix.py }}
                   architecture: x64
             - run: pip install tox
             - name: Running tox
-              run: tox -e ${{ matrix.tox.env }}
+              run: tox -e py
     coverage:
         runs-on: ubuntu-latest
         name: Validate coverage for Python 2/3

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,24 +7,26 @@ jobs:
         runs-on: macOS-latest
         strategy:
             matrix:
-                tox: [
-                    {'py': '2.7', 'env': 'py27'},
-                    {'py': '3.5', 'env': 'py35'},
-                    {'py': '3.6', 'env': 'py36'},
-                    {'py': '3.7', 'env': 'py37'},
-                    {'py': '3.8', 'env': 'py38'},
+                py: [
+                    '2.7',
+                    '3.5',
+                    '3.6',
+                    '3.7',
+                    '3.8',
+                    'pypy2',
+                    'pypy3'
                 ]
                 architecture: ['x64']
-        name: "Python: ${{ matrix.tox.py }}"
+        name: "Python: ${{ matrix.py }}"
         steps:
             - uses: actions/checkout@master
             - name: Setup python
               uses: actions/setup-python@v1
               with:
-                  python-version: ${{ matrix.tox.py }}
+                  python-version: ${{ matrix.py }}
                   architecture: ${{ matrix.architecture }}
             - run: pip install tox
             - name: Running tox
               run: |
                   ulimit -n 4096
-                  tox -e ${{ matrix.tox.env }}
+                  tox -e py

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,6 +12,7 @@ jobs:
                     {'py': '3.5', 'env': 'py35'},
                     {'py': '3.6', 'env': 'py36'},
                     {'py': '3.7', 'env': 'py37'},
+                    {'py': '3.8', 'env': 'py38'},
                 ]
                 architecture: ['x64']
         name: "Python: ${{ matrix.tox.py }}"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,6 +12,7 @@ jobs:
                     {'py': '3.5', 'env': 'py35'},
                     {'py': '3.6', 'env': 'py36'},
                     {'py': '3.7', 'env': 'py37'},
+                    {'py': '3.8', 'env': 'py38'},
                 ]
                 architecture: ['x86', 'x64']
         name: "Python: ${{ matrix.tox.py }} (${{ matrix.architecture }})"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -7,22 +7,22 @@ jobs:
         runs-on: windows-2019
         strategy:
             matrix:
-                tox: [
-                    {'py': '2.7', 'env': 'py27'},
-                    {'py': '3.5', 'env': 'py35'},
-                    {'py': '3.6', 'env': 'py36'},
-                    {'py': '3.7', 'env': 'py37'},
-                    {'py': '3.8', 'env': 'py38'},
+                py: [
+                    '2.7',
+                    '3.5',
+                    '3.6',
+                    '3.7',
+                    '3.8'
                 ]
                 architecture: ['x86', 'x64']
-        name: "Python: ${{ matrix.tox.py }} (${{ matrix.architecture }})"
+        name: "Python: ${{ matrix.py }} (${{ matrix.architecture }})"
         steps:
             - uses: actions/checkout@master
             - name: Setup python
               uses: actions/setup-python@v1
               with:
-                  python-version: ${{ matrix.tox.py }}
+                  python-version: ${{ matrix.py }}
                   architecture: ${{ matrix.architecture }}
             - run: pip install tox
             - name: Running tox
-              run: tox -e ${{ matrix.tox.env }}
+              run: tox -e py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.4
-          env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
         - python: 3.6
@@ -16,7 +14,7 @@ matrix:
           env: TOXENV=py37
           dist: xenial
           sudo: true
-        - python: 3.8-dev
+        - python: 3.8
           env: TOXENV=py38
           dist: xenial
           sudo: true
@@ -28,8 +26,6 @@ matrix:
           env: TOXENV=py27-cover,py35-cover,coverage
         - python: 3.5
           env: TOXENV=docs
-    allow_failures:
-        - env: TOXENV=py38
 
 install:
   - travis_retry pip install tox

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Waitress
 Waitress is meant to be a production-quality pure-Python WSGI server with very
 acceptable performance.  It has no dependencies except ones which live in the
 Python standard library.  It runs on CPython on Unix and Windows under Python
-2.7+ and Python 3.4+.  It is also known to run on PyPy 1.6.0+ on UNIX.  It
+2.7+ and Python 3.5+.  It is also known to run on PyPy 1.6.0+ on UNIX.  It
 supports HTTP/1.0 and HTTP/1.1.
 
 For more information, see the "docs" directory of the Waitress package or visit https://docs.pylonsproject.org/projects/waitress/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Waitress
 Waitress is meant to be a production-quality pure-Python WSGI server with
 very acceptable performance.  It has no dependencies except ones which live
 in the Python standard library.  It runs on CPython on Unix and Windows under
-Python 2.7+ and Python 3.4+.  It is also known to run on PyPy 1.6.0 on UNIX.
+Python 2.7+ and Python 3.5+.  It is also known to run on PyPy 1.6.0 on UNIX.
 It supports HTTP/1.0 and HTTP/1.1.
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@
 #
 ##############################################################################
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
@@ -52,7 +53,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -65,7 +65,8 @@ setup(
     ],
     url="https://github.com/Pylons/waitress",
     packages=find_packages(),
-    extras_require={"testing": testing_extras, "docs": docs_extras,},
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+    extras_require={"testing": testing_extras, "docs": docs_extras},
     include_package_data=True,
     test_suite="waitress",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 
 [testenv]
 commands =
+    python --version
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:waitress}
 
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,pypy3,
+    py27,py35,py36,py37,py38,pypy,pypy3,
     docs,
     {py27,py35}-cover,coverage
 


### PR DESCRIPTION
This is necessary due to needing coverage>=5.0, which is no longer
available on Python 3.4.

Python 3.4 is also now past end of life.

This continued to work by chance due to Travis having nosetest installed
in the Python global installation, and thus the failure from tox to
install coverage>=5.0 did not cause errors on Travis.

Testing locally I still had an old version of coverage installed, and
that version had not yet dropped Python 3.4.