### PR TITLE
Fix simple typo: seperated -> separated

### DIFF
--- a/waitress/parser.py
+++ b/waitress/parser.py
@@ -224,8 +224,8 @@ class HTTPRequestParser(object):
             value = value.strip(b" \t")
             key1 = tostr(key.upper().replace(b"-", b"_"))
             # If a header already exists, we append subsequent values
-            # seperated by a comma. Applications already need to handle
-            # the comma seperated values, as HTTP front ends might do
+            # separated by a comma. Applications already need to handle
+            # the comma separated values, as HTTP front ends might do
             # the concatenation for you (behavior specified in RFC2616).
             try:
                 headers[key1] += tostr(b", " + value)

--- a/waitress/tests/test_wasyncore.py
+++ b/waitress/tests/test_wasyncore.py
@@ -125,7 +125,7 @@ def gc_collect():  # pragma: no cover
     In non-CPython implementations of Python, this is needed because timely
     deallocation is not guaranteed by the garbage collector.  (Even in CPython
     this can be the case in case of reference cycles.)  This means that __del__
-    methods may be called later than expected and weakrefs may remain alive for
+    methods may be called later than expected and weakref may remain alive for
     longer than expected.  This function tries its best to force all garbage
     objects to disappear.
     """

--- a/waitress/tests/test_wasyncore.py
+++ b/waitress/tests/test_wasyncore.py
@@ -125,7 +125,7 @@ def gc_collect():  # pragma: no cover
     In non-CPython implementations of Python, this is needed because timely
     deallocation is not guaranteed by the garbage collector.  (Even in CPython
     this can be the case in case of reference cycles.)  This means that __del__
-    methods may be called later than expected and weakref may remain alive for
+    methods may be called later than expected and weakrefs may remain alive for
     longer than expected.  This function tries its best to force all garbage
     objects to disappear.
     """


### PR DESCRIPTION
There is a small typo in waitress/parser.py.
Should read `separated` rather than `seperated`.

