### PR TITLE
add project_urls and py38

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,18 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: WSGI
 url = https://github.com/Pylons/waitress
+project_urls =
+    Documentation = https://docs.pylonsproject.org/projects/waitress/en/latest/index.html
+    Changelog = https://docs.pylonsproject.org/projects/waitress/en/latest/index.html#change-history
+    Issue Tracker = https://github.com/Pylons/waitress/issues
+
 author = Zope Foundation and Contributors
 author_email = zope-dev@zope.org
 maintainer = Pylons Project


### PR DESCRIPTION
I wasn't sure whether to also update:

```cfg
author = Zope Foundation and Contributors
author_email = zope-dev@zope.org
```

I sent a test email to `zope-dev@zope.org`, and it didn't bounce. I don't know if it is monitored.