### PR TITLE
Enable an option to disable the root logging config

### DIFF
--- a/src/waitress/__init__.py
+++ b/src/waitress/__init__.py
@@ -6,7 +6,8 @@ def serve(app, **kw):
     _server = kw.pop("_server", create_server)  # test shim
     _quiet = kw.pop("_quiet", False)  # test shim
     _profile = kw.pop("_profile", False)  # test shim
-    if not _quiet:  # pragma: no cover
+    disable_root_log_config = kw.pop("disable_root_log_config", False)
+    if not _quiet and not disable_root_log_config:  # pragma: no cover
         # idempotent if logging has already been set up
         logging.basicConfig()
     server = _server(app, **kw)


### PR DESCRIPTION
## Issue

Fixes: #298 

## Background
At the moment, `waitress` would always set up the root logger with `logging.basicConfig()`.

There are two major kinds of issue could be generated:

#### Unnecessary waitress noise
`wairtess` could print out a lot of messages, which for most of the cases, it's not really necessary for the application.

#### Interference with application logging
As it has configured the root logger, which would generate additional unintended log output.

## Changes

This will give users an option to disable the root logger logging configure, and leave the `_quiet` as it is, so that certain information could still be printed out.

![image](https://user-images.githubusercontent.com/52658745/82204406-6847ac00-9937-11ea-9934-b21b678ec485.png)


## Ref

https://github.com/Pylons/waitress/issues/151
https://github.com/Pylons/waitress/issues/235


## Note

There is another workaround to turn off the logging of `waitress` completely by using the `_quiet` parameter, ref: https://github.com/Pylons/waitress/issues/133#issuecomment-629992140

However, since it's said as `test shim`, I am proposing to add a new parameter here. Thanks.