### PR TITLE
stabilize buffer behavior with multiple requests on the same connection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,14 @@
+Unreleased
+----------
+
+- Fix an issue with keep-alive connections in which memory usage was higher
+  than expected because output buffers were being reused across requests on
+  a long-lived connection and each buffer would not be freed until it was full
+  or the connection was closed. Buffers are now rotated per-request to
+  stabilize their behavior.
+
+  See https://github.com/Pylons/waitress/pull/300
+
 1.4.3 (2020-02-02)
 ------------------
 


### PR DESCRIPTION
previous to this change, a buffer may be reused across requests, and would not free its memory until it was full. We would prefer that only occur if a request is actually writing a large response, and across requests memory should be released. It also triggered a lot of unnecessary writing of data to disk on later requests since the outbuf-overflow would be reached on previous requests.

fixes #265