### PR TITLE
Fix: thread name

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,12 @@ Unreleased
 
   See https://github.com/Pylons/waitress/pull/300
 
+- Waitress threads have been updated to contain their thread number. This will
+  allow loggers that use that information to print the thread that the log is
+  coming from.
+
+  See https://github.com/Pylons/waitress/pull/302
+
 1.4.3 (2020-02-02)
 ------------------
 

--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -57,8 +57,10 @@ class ThreadedTaskDispatcher(object):
         self.queue_cv = threading.Condition(self.lock)
         self.thread_exit_cv = threading.Condition(self.lock)
 
-    def start_new_thread(self, target, args):
-        t = threading.Thread(target=target, name="waitress", args=args)
+    def start_new_thread(self, target, thread_no):
+        t = threading.Thread(
+            target=target, name="waitress-{}".format(thread_no), args=(thread_no,)
+        )
         t.daemon = True
         t.start()
 
@@ -96,7 +98,7 @@ class ThreadedTaskDispatcher(object):
                     thread_no = thread_no + 1
                 threads.add(thread_no)
                 running += 1
-                self.start_new_thread(self.handler_thread, (thread_no,))
+                self.start_new_thread(self.handler_thread, thread_no)
                 self.active_count += 1
                 thread_no = thread_no + 1
             if running > count:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -34,7 +34,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         L = []
         inst.start_new_thread = lambda *x: L.append(x)
         inst.set_thread_count(1)
-        self.assertEqual(L, [(inst.handler_thread, (0,))])
+        self.assertEqual(L, [(inst.handler_thread, 0)])
 
     def test_set_thread_count_increase_with_existing(self):
         inst = self._makeOne()
@@ -42,7 +42,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst.threads = {0}
         inst.start_new_thread = lambda *x: L.append(x)
         inst.set_thread_count(2)
-        self.assertEqual(L, [(inst.handler_thread, (1,))])
+        self.assertEqual(L, [(inst.handler_thread, 1)])
 
     def test_set_thread_count_decrease(self):
         inst = self._makeOne()


### PR DESCRIPTION
Somewhere along the lines the thread name got set to just `waitress` rather than something that identifies thread number it is, this adds the thread number back to the name of the thread.