### PR TITLE
Update usage.rst to include reference Heroku

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -80,4 +80,11 @@ can be used in development and in situations where the likes of
     # Listen on only IPv4 on port 8041
     waitress-serve --port=8041 myapp:wsgifunc
 
+Waitress can be used to serve WSGI apps on Heroku, include waitress in your
+requirements.txt file a update the Procfile as following:
+
+.. code-block:: bash
+
+    web: waitress-serve --port=$PORT myapp:wsgifunc
+
 For more information on this, see :ref:`runner`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -85,6 +85,18 @@ requirements.txt file a update the Procfile as following:
 
 .. code-block:: bash
 
-    web: waitress-serve --port=$PORT myapp:wsgifunc
+    web: waitress-serve \
+  --listen "*:$PORT" \
+  --trusted-proxy '*' \
+  --trusted-proxy-headers 'x-forwarded-for x-forwarded-proto x-forwarded-port' \
+  --log-untrusted-proxy-headers \
+  --clear-untrusted-proxy-headers \
+  --threads ${WEB_CONCURRENCY:-4} \
+  myapp:wsgifunc
+
+Note that Waitress uses a thread-based model and careful effort should be taken to ensure
+that requests do not take longer than 30 seconds or Heroku will inform the client that the
+request failed even though the request is still being processed by waitress and occupying
+a thread until it completes.
 
 For more information on this, see :ref:`runner`.


### PR DESCRIPTION
Many people is using  waitress over gunircon to serve python apps on Heroku, so I think it is nice to include it referece on the waitress docs.

Signed-off-by: William Moreno Reyes <williamjmorenor@gmail.com>