### PR TITLE
Use log_info instead of print in print_listen

### DIFF
--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -356,7 +356,7 @@ class BaseWSGIServer(wasyncore.dispatcher):
                 channel.will_close = True
 
     def print_listen(self, format_str):  # pragma: nocover
-        print(format_str.format(self.effective_host, self.effective_port))
+        self.log_info(format_str.format(self.effective_host, self.effective_port))
 
     def close(self):
         self.trigger.close()


### PR DESCRIPTION
The problem:

I would like to catch "Serving on...." message using python logging module and process it later in my appllication.
https://github.com/Pylons/waitress/blob/e2adf082e6942ee785bbc447beaa2c4d9764893f/src/waitress/__init__.py#L15
Currently, it outputs to stdout and could not be handled by logging system. 

Solution:
replace `print` with `log_info` (a wrapper for logging module)


Merging it before releasing 2.0 would help me a lot

Connected with https://github.com/Pylons/waitress/issues/133