### PR TITLE
Fix X-Forwarded-Host

### DIFF
--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -73,7 +73,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-Note that if your external proxy (for a pod or ingress) is serving a port that is different from your internal proxy (for a container), you may need to use ``$http_host`` to include the external port in ``request.route_url``. This is because the value of ``$server_port`` that is forwarded to your pyramid application will reference the value from the internal proxy, which is probably not what you want (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
+Note that if your external proxy (for a pod or ingress) is serving a port that is different from your internal proxy (for a container), you may need to use ``$http_host`` to include the external port in ``request.route_url``. This is because the value of ``$server_port`` that is forwarded to your pyramid application will reference the value from the internal proxy, which is probably not what you want.
 
 .. code-block:: nginx
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -73,7 +73,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-Note that if your proxy is running on a port other than 80 or 443, you may need to use ``$http_host`` to include the non-standard port in ``request.route_url`` (see https://stackoverflow.com/questions/1459739/php-serverhttp-host-vs-serverserver-name-am-i-understanding-the-ma/12046836#12046836).
+Note that if your external proxy (for a pod or ingress) is serving a port other than 80 or 443 but your internal proxy (for a container) is serving a standard port, you may need to use ``$http_host`` to include the non-standard port in ``request.route_url``. This is because the internal proxy will not populate ``$server_port`` when it is serving a standard port (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
 
 .. code-block:: nginx
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -73,7 +73,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-Note that if your external proxy (for a pod or ingress) is serving a port other than 80 or 443 but your internal proxy (for a container) is serving a standard port, you may need to use ``$http_host`` to include the non-standard port in ``request.route_url``. This is because the internal proxy will not populate ``$server_port`` when it is serving a standard port (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
+Note that if your external proxy (for a pod or ingress) is serving a port that is different from your internal proxy (for a container), you may need to use ``$http_host`` to include the external port in ``request.route_url``. This is because the value of ``$server_port`` that is forwarded to your pyramid application will reference the value for the internal proxy, which is probably not what you want (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
 
 .. code-block:: nginx
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -73,7 +73,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-Note that if your external proxy (for a pod or ingress) is serving a port that is different from your internal proxy (for a container), you may need to use ``$http_host`` to include the external port in ``request.route_url``. This is because the value of ``$server_port`` that is forwarded to your pyramid application will reference the value for the internal proxy, which is probably not what you want (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
+Note that if your external proxy (for a pod or ingress) is serving a port that is different from your internal proxy (for a container), you may need to use ``$http_host`` to include the external port in ``request.route_url``. This is because the value of ``$server_port`` that is forwarded to your pyramid application will reference the value from the internal proxy, which is probably not what you want (see https://github.com/Pylons/waitress/pull/319#issuecomment-705853859).
 
 .. code-block:: nginx
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -68,10 +68,14 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
 
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   proxy_set_header X-Forwarded-Host $http_host;
+   proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-when using Apache, ``mod_proxy`` automatically forwards the following headers::
+Note that if your proxy is running on a port other than 80 or 443, you may need to use ``$http_host`` to include the non-standard port in `request.route_url` (see https://stackoverflow.com/questions/1459739/php-serverhttp-host-vs-serverserver-name-am-i-understanding-the-ma/12046836#12046836).
+
+   proxy_set_header X-Forwarded-Host $http_host;
+
+When using Apache, ``mod_proxy`` automatically forwards the following headers::
 
    X-Forwarded-For
    X-Forwarded-Host

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -68,7 +68,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
 
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   proxy_set_header X-Forwarded-Host $host:$server_port;
+   proxy_set_header X-Forwarded-Host $http_host;
    proxy_set_header X-Forwarded-Port $server_port;
 
 when using Apache, ``mod_proxy`` automatically forwards the following headers::

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -64,7 +64,9 @@ If your proxy accepts both HTTP and HTTPS URLs, and you want your application
 to generate the appropriate url based on the incoming scheme, you'll want to
 pass waitress ``X-Forwarded-Proto``, however Waitress is also able to update
 the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
-``X-Forwarded-Host``, and ``X-Forwarded-Port``::
+``X-Forwarded-Host``, and ``X-Forwarded-Port``
+
+.. code-block:: nginx
 
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -72,6 +74,8 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Port $server_port;
 
 Note that if your proxy is running on a port other than 80 or 443, you may need to use ``$http_host`` to include the non-standard port in `request.route_url` (see https://stackoverflow.com/questions/1459739/php-serverhttp-host-vs-serverserver-name-am-i-understanding-the-ma/12046836#12046836).
+
+.. code-block:: nginx
 
    proxy_set_header X-Forwarded-Host $http_host;
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -73,7 +73,7 @@ the environment using ``X-Forwarded-Proto``, ``X-Forwarded-For``,
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Forwarded-Port $server_port;
 
-Note that if your proxy is running on a port other than 80 or 443, you may need to use ``$http_host`` to include the non-standard port in `request.route_url` (see https://stackoverflow.com/questions/1459739/php-serverhttp-host-vs-serverserver-name-am-i-understanding-the-ma/12046836#12046836).
+Note that if your proxy is running on a port other than 80 or 443, you may need to use ``$http_host`` to include the non-standard port in ``request.route_url`` (see https://stackoverflow.com/questions/1459739/php-serverhttp-host-vs-serverserver-name-am-i-understanding-the-ma/12046836#12046836).
 
 .. code-block:: nginx
 


### PR DESCRIPTION
Under the previous configuration `proxy_set_header X-Forwarded-Host $host:$server_port`, `request.route_url` does not respect a non-standard port such as http://example.com:8000

Under the proposed configuration `proxy_set_header X-Forwarded-Host $http_host`, `request.route_url` does respect a non-standard port such as http://example.com:8000