### PR TITLE
Updates MultiSocketServer to use log_info instead of print

### DIFF
--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -156,7 +156,7 @@ class MultiSocketServer:
             if ":" in l[0]:
                 l[0] = "[{}]".format(l[0])
 
-            print(format_str.format(*l))
+            self.log_info(format_str.format(*l))
 
     def run(self):
         try:


### PR DESCRIPTION
#315 Updated `BaseWSGIServer` to use `self.log_info` but not `MultiSocketServer` (see https://github.com/Pylons/waitress/pull/315#issuecomment-709946842).

This PR applied the same modifications to `MultiSocketServer`