### PR TITLE
Cleanup: Server Name deduction logic

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,13 +1,22 @@
 2.0.0 (unreleased)
 ------------------
+
+- Waitress no longer attempts to guess at what the ``server_name`` should be for
+  a listen socket, instead it always use a new adjustment/argument named
+  ``server_name``.
+
+  Please see the documentation for ``server_name`` in
+  https://docs.pylonsproject.org/projects/waitress/en/latest/arguments.html and
+  see https://github.com/Pylons/waitress/pull/329
+
 - Allow tasks to notice if the client disconnected.
 
-  This inserts a callable `waitress.client_disconnected` into the environment
+  This inserts a callable ``waitress.client_disconnected`` into the environment
   that allows the task to check if the client disconnected while waiting for
   the response at strategic points in the execution and to cancel the
   operation.
 
-  It requires setting the new adjustment `channel_request_lookahead` to a value
+  It requires setting the new adjustment ``channel_request_lookahead`` to a value
   larger than 0, which continues to read requests from a channel even if a
   request is already being processed on that channel, up to the given count,
   since a client disconnect is detected by reading from a readable socket and
@@ -15,7 +24,7 @@
 
   See https://github.com/Pylons/waitress/pull/310
 
-- Drop Python 2.7 support
+- Drop Python 2.7, 3.5 support
 
 - The server now issues warning output when it there are enough open
   connections (controlled by "connection_limit"), that it is no longer

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -35,6 +35,23 @@ listen
 
     .. versionadded:: 1.0
 
+server_name
+    This is the value that will be placed in the WSGI environment as
+    ``SERVER_NAME``, the only time that this value is used in the WSGI
+    environment for a request is if the client sent a HTTP/1.0 request without
+    a ``Host`` header set, and no other proxy headers.
+
+    The default is value is ``waitress.invalid``, if your WSGI application is
+    creating URL's that include this as the hostname and you are using a
+    reverse proxy setup, you may want to validate that your reverse proxy is
+    sending the appropriate headers.
+
+    In most situations you will not need to set this value.
+
+    Default: ``waitress.invalid``
+
+    .. versionadded:: 2.0
+
 ipv4
     Enable or disable IPv4 (boolean)
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -136,6 +136,7 @@ class Adjustments:
         ("unix_socket_perms", asoctal),
         ("sockets", as_socket_list),
         ("channel_request_lookahead", int),
+        ("server_name", str),
     )
 
     _param_map = dict(_params)
@@ -287,6 +288,11 @@ class Adjustments:
     # This allows detecting if a client closed the connection while its request
     # is being processed.
     channel_request_lookahead = 0
+
+    # This setting controls the SERVER_NAME of the WSGI environment, this is
+    # only ever used if the remote client sent a request without a Host header
+    # (or when using the Proxy settings, without forwarding a Host header)
+    server_name = "waitress.invalid"
 
     def __init__(self, **kw):
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,35 +113,6 @@ class TestWSGIServer(unittest.TestCase):
         inst = self._makeOneWithMap(_start=False)
         self.assertEqual(inst.accepting, False)
 
-    def test_get_server_name_empty(self):
-        inst = self._makeOneWithMap(_start=False)
-        self.assertRaises(ValueError, inst.get_server_name, "")
-
-    def test_get_server_name_with_ip(self):
-        inst = self._makeOneWithMap(_start=False)
-        result = inst.get_server_name("127.0.0.1")
-        self.assertTrue(result)
-
-    def test_get_server_name_with_hostname(self):
-        inst = self._makeOneWithMap(_start=False)
-        result = inst.get_server_name("fred.flintstone.com")
-        self.assertEqual(result, "fred.flintstone.com")
-
-    def test_get_server_name_0000(self):
-        inst = self._makeOneWithMap(_start=False)
-        result = inst.get_server_name("0.0.0.0")
-        self.assertTrue(len(result) != 0)
-
-    def test_get_server_name_double_colon(self):
-        inst = self._makeOneWithMap(_start=False)
-        result = inst.get_server_name("::")
-        self.assertTrue(len(result) != 0)
-
-    def test_get_server_name_ipv6(self):
-        inst = self._makeOneWithMap(_start=False)
-        result = inst.get_server_name("2001:DB8::ffff")
-        self.assertEqual("[2001:DB8::ffff]", result)
-
     def test_get_server_multi(self):
         inst = self._makeOneWithMulti()
         self.assertEqual(inst.__class__.__name__, "MultiSocketServer")


### PR DESCRIPTION
Waitress always used to assume that it would be running on a system where there was a correctly implemented DNS system that would return the hostname when doing a reverse DNS lookup on the IP address it was bound to, or that the system would return the IP address itself.

This is however not the case as seen in https://github.com/Pylons/waitress/issues/312, https://github.com/Pylons/waitress/issues/283, https://github.com/Pylons/waitress/issues/268 and issues in https://github.com/Pylons/waitress/issues/149.

So now the logic is simplified even further. We don't attempt do anything of the sort anymore at all. Waitress has learned a new configuration value called `server_name`. The default is `waitress.invalid`. 

The only time that a user will see this value if the following is true: the request arrives over HTTP 1.0 and the remote client does not set a Host header.

In no other situation does the `server_name` value, which is used in the WSGI environment `SERVER_NAME` matter because it should be overridden with the `Host` header sent by the client, or if using a Proxy, can be set on `Forwarded`/`X-Forwarded-Host`.

Closes #312 
Closes #150