### PR TITLE
fix a crash in the MultiSocketServer startup and re-enable startup messages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Fix a crash on startup when listening to multiple interfaces.
+  See https://github.com/Pylons/waitress/pull/332
+
 2.0.0b0 (2020-11-26)
 --------------------
 

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -16,6 +16,7 @@
 
 
 import getopt
+import logging
 import os
 import os.path
 import re
@@ -23,6 +24,7 @@ import sys
 
 from waitress import serve
 from waitress.adjustments import Adjustments
+from waitress.utilities import logger
 
 HELP = """\
 Usage:
@@ -259,6 +261,12 @@ def run(argv=sys.argv, _serve=serve):
     if len(args) != 1:
         show_help(sys.stderr, name, "Specify one application only")
         return 1
+
+    # set a default level for the logger only if it hasn't been set explicitly
+    # note that this level does not override any parent logger levels,
+    # handlers, etc but without it no log messages are emitted by default
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
 
     try:
         module, obj_name = match(args[0])

--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -125,10 +125,11 @@ def create_server(
         # In this case we have no need to use a MultiSocketServer
         return last_serv
 
+    log_info = last_serv.log_info
     # Return a class that has a utility function to print out the sockets it's
     # listening on, and has a .run() function. All of the TcpWSGIServers
     # registered themselves in the map above.
-    return MultiSocketServer(map, adj, effective_listen, dispatcher)
+    return MultiSocketServer(map, adj, effective_listen, dispatcher, log_info)
 
 
 # This class is only ever used if we have multiple listen sockets. It allows
@@ -143,11 +144,13 @@ class MultiSocketServer:
         adj=None,
         effective_listen=None,
         dispatcher=None,
+        log_info=None,
     ):
         self.adj = adj
         self.map = map
         self.effective_listen = effective_listen
         self.task_dispatcher = dispatcher
+        self.log_info = log_info
 
     def print_listen(self, format_str):  # pragma: nocover
         for l in self.effective_listen:
@@ -344,7 +347,7 @@ class BaseWSGIServer(wasyncore.dispatcher):
             if (not channel.requests) and channel.last_activity < cutoff:
                 channel.will_close = True
 
-    def print_listen(self, format_str):  # pragma: nocover
+    def print_listen(self, format_str):  # pragma: no cover
         self.log_info(format_str.format(self.effective_host, self.effective_port))
 
     def close(self):


### PR DESCRIPTION
1) fixes #331 

2) no output was displayed by default because the root logger defaults to WARNING level and this level is inherited by any logger that does not have their own level defined. Since waitress is being run as the entry point, I think it's ok for waitress to configure its own effective logging level and set it to INFO triggering its messages to emit by default.