### PR TITLE
Add the decode_path adjustment

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+Next Release
+------------
+
+- Add the decode_path adjustment.
+
+  The decode_path adjustment is enabled by default. Disable it for apps
+  that need to distinguish between encoded and non-encoded characters
+  in the path. For example, some apps need to allow encoded slashes in
+  path segments.
+
 2.0.0 (2021-03-07)
 ------------------
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -301,3 +301,12 @@ url_prefix
     be stripped of the prefix.
 
     Default: ``''``
+
+decode_path
+    Set to ``False`` to disable path decoding. When ``decode_path`` is true
+    (the default), waitress decodes the ``%XX`` escaped characters in the path.
+    If your app needs to distinguish between encoded and non-encoded characters
+    (especially slash characters), set this to ``False`` and add the path
+    decoding logic inside your app.
+
+    Default: ``True``

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -137,6 +137,7 @@ class Adjustments:
         ("sockets", as_socket_list),
         ("channel_request_lookahead", int),
         ("server_name", str),
+        ("decode_path", asbool),
     )
 
     _param_map = dict(_params)
@@ -293,6 +294,10 @@ class Adjustments:
     # only ever used if the remote client sent a request without a Host header
     # (or when using the Proxy settings, without forwarding a Host header)
     server_name = "waitress.invalid"
+
+    # Decode %XX escapes in the path. Enabled by default. If false,
+    # waitress decodes the path bytes as 'latin-1' and applies no URL decoding.
+    decode_path = True
 
     def __init__(self, **kw):
 

--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -258,7 +258,7 @@ class HTTPRequestParser:
             self.path,
             self.query,
             self.fragment,
-        ) = split_uri(uri)
+        ) = split_uri(uri, adj=self.adj)
         self.url_scheme = self.adj.url_scheme
         connection = headers.get("CONNECTION", "")
 
@@ -340,7 +340,7 @@ class HTTPRequestParser:
             body_rcv.getbuf().close()
 
 
-def split_uri(uri):
+def split_uri(uri, adj=None):
     # urlsplit handles byte input by returning bytes on py3, so
     # scheme, netloc, path, query, and fragment are bytes
 
@@ -367,10 +367,15 @@ def split_uri(uri):
         except UnicodeError:
             raise ParsingError("Bad URI")
 
+    if adj is None or adj.decode_path:
+        final_path = unquote_bytes_to_wsgi(path)
+    else:
+        final_path = path.decode("latin-1")
+
     return (
         scheme.decode("latin-1"),
         netloc.decode("latin-1"),
-        unquote_bytes_to_wsgi(path),
+        final_path,
         query.decode("latin-1"),
         fragment.decode("latin-1"),
     )

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -177,6 +177,8 @@ Tuning options:
         detecting if a client closed the connection while its request is being
         processed. Default is 0.
 
+    --[no-]decode-path
+        Decode URL-escaped characters in the path. Enabled by default.
 """
 
 RUNNER_PATTERN = re.compile(

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -63,7 +63,8 @@ Standard options:
         A wildcard for the hostname is also supported and will bind to both
         IPv4/IPv6 depending on whether they are enabled or disabled.
 
-    --[no-]ipv4
+    --ipv4
+    --no-ipv4
         Toggle on/off IPv4 support.
 
         Example:
@@ -73,7 +74,8 @@ Standard options:
         This will disable IPv4 socket support. This affects wildcard matching
         when generating the list of sockets.
 
-    --[no-]ipv6
+    --ipv6
+    --no-ipv6
         Toggle on/off IPv6 support.
 
         Example:
@@ -149,7 +151,8 @@ Tuning options:
         Default is 120. 'Inactive' is defined as 'has received no data
         from the client and has sent no data to the client'.
 
-    --[no-]log-socket-errors
+    --log-socket-errors
+    --no-log-socket-errors
         Toggle whether premature client disconnect tracebacks ought to be
         logged. On by default.
 
@@ -160,7 +163,8 @@ Tuning options:
     --max-request-body-size=INT
         Maximum size of request body. Default is 1073741824 (1GB).
 
-    --[no-]expose-tracebacks
+    --expose-tracebacks
+    --no-expose-tracebacks
         Toggle whether to expose tracebacks of unhandled exceptions to the
         client. Off by default.
 
@@ -177,7 +181,8 @@ Tuning options:
         detecting if a client closed the connection while its request is being
         processed. Default is 0.
 
-    --[no-]decode-path
+    --decode-path
+    --no-decode-path
         Decode URL-escaped characters in the path. Enabled by default.
 """
 

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -183,7 +183,8 @@ Tuning options:
 
     --decode-path
     --no-decode-path
-        Decode URL-escaped characters in the path. Enabled by default.
+        Toggle whether to decode URL-escaped characters in the path. Enabled
+        by default.
 """
 
 RUNNER_PATTERN = re.compile(

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -164,6 +164,7 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.url_prefix, "/foo")
         self.assertEqual(inst.ipv4, True)
         self.assertEqual(inst.ipv6, False)
+        self.assertEqual(inst.decode_path, True)
 
         bind_pairs = [
             sockaddr[:2]
@@ -398,6 +399,10 @@ class TestAdjustments(unittest.TestCase):
 
         inst = self._makeOne(ident="specific_header")
         self.assertEqual(inst.ident, "specific_header")
+
+    def test_decode_path_false(self):
+        inst = self._makeOne(decode_path="false")
+        self.assertEqual(inst.decode_path, False)
 
 
 class TestCLI(unittest.TestCase):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -928,6 +928,7 @@ class DummyAdjustments:
     url_prefix = ""
     channel_request_lookahead = 0
     max_request_body_size = 1048576
+    decode_path = True
 
 
 class DummyServer:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -415,14 +415,14 @@ class TestHTTPRequestParser(unittest.TestCase):
 
 
 class Test_split_uri(unittest.TestCase):
-    def _callFUT(self, uri):
+    def _callFUT(self, uri, adj=None):
         (
             self.proxy_scheme,
             self.proxy_netloc,
             self.path,
             self.query,
             self.fragment,
-        ) = split_uri(uri)
+        ) = split_uri(uri, adj)
 
     def test_split_uri_unquoting_unneeded(self):
         self._callFUT(b"http://localhost:8080/abc def")
@@ -486,6 +486,11 @@ class Test_split_uri(unittest.TestCase):
         self.assertEqual(self.proxy_netloc, "")
         self.assertEqual(self.query, "a=1&b=2")
         self.assertEqual(self.fragment, "fragment")
+
+    def test_split_uri_without_decode_path(self):
+        adj = Adjustments(decode_path=False)
+        self._callFUT(b"http://localhost:8080/%2F/", adj=adj)
+        self.assertEqual(self.path, "/%2F/")
 
 
 class Test_get_header_lines(unittest.TestCase):


### PR DESCRIPTION
This patch adds the `decode_path` adjustment, enabled by default. When it's disabled, waitress will no longer decode `%XX` characters in the path, expecting the downstream app to do that.

I need this because some of the apps I'm working on allow encoded slashes in the path, so they need to decode `/%2F/x` as a path segment list, `["/", "x"]`, which isn't possible when waitress decodes `/%2F/x` as `///x`.

Setting `decode_path = False` is similar to setting `AllowEncodedSlashes NoDecode` in Apache.
