### PR TITLE
Add REQUEST_URI

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,9 @@
 Next Release
 ------------
 
-- Add REMOTE_URI to the WSGI environment.
+- Add REQUEST_URI to the WSGI environment.
 
-  REMOTE_URI is similar to ``remote_uri`` in nginx. It is a string that
+  REQUEST_URI is similar to ``request_uri`` in nginx. It is a string that
   contains the request path before separating the query string and
   decoding ``%``-escaped characters. 
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Next Release
+------------
+
+- Add REMOTE_URI to the WSGI environment.
+
+  REMOTE_URI is similar to ``remote_uri`` in nginx. It is a string that
+  contains the request path before separating the query string and
+  decoding ``%``-escaped characters. 
+
 2.0.0 (2021-03-07)
 ------------------
 

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -25,7 +25,7 @@ from . import wasyncore
 
 
 class ClientDisconnected(Exception):
-    """ Raised when attempting to write to a closed socket."""
+    """Raised when attempting to write to a closed socket."""
 
 
 class HTTPChannel(wasyncore.dispatcher):
@@ -480,7 +480,7 @@ class HTTPChannel(wasyncore.dispatcher):
         self.last_activity = time.time()
 
     def cancel(self):
-        """ Cancels all pending / active requests """
+        """Cancels all pending / active requests"""
         self.will_close = True
         self.connected = False
         self.last_activity = time.time()

--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -248,6 +248,9 @@ class HTTPRequestParser:
 
         # command, uri, version will be bytes
         command, uri, version = crack_first_line(first_line)
+        # self.request_uri is like nginx's request_uri:
+        # "full original request URI (with arguments)"
+        self.request_uri = uri.decode("latin-1")
         version = version.decode("latin-1")
         command = command.decode("latin-1")
         self.command = command

--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -538,6 +538,7 @@ class WSGITask(Task):
             "SERVER_PROTOCOL": "HTTP/%s" % self.version,
             "SCRIPT_NAME": url_prefix,
             "PATH_INFO": path,
+            "REQUEST_URI": request.request_uri,
             "QUERY_STRING": request.query,
             "wsgi.url_scheme": request.url_scheme,
             # the following environment variables are required by the WSGI spec

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -608,6 +608,11 @@ class TestHTTPRequestParserIntegration(unittest.TestCase):
             parser.path.encode("latin-1").decode("utf-8"),
             b"/foo/a++/\xc3\xa4=&a:int".decode("utf-8"),
         )
+        # parser.request_uri should preserve the % escape sequences and the query string.
+        self.assertEqual(
+            parser.request_uri,
+            "/foo/a+%2B%2F%C3%A4%3D%26a%3Aint?d=b+%2B%2F%3D%26b%3Aint&c+%2B%2F%3D%26c%3Aint=6",
+        )
         self.assertEqual(
             parser.query, "d=b+%2B%2F%3D%26b%3Aint&c+%2B%2F%3D%26c%3Aint=6"
         )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -797,6 +797,7 @@ class TestWSGITask(unittest.TestCase):
                 "REMOTE_HOST",
                 "REMOTE_PORT",
                 "REQUEST_METHOD",
+                "REQUEST_URI",
                 "SCRIPT_NAME",
                 "SERVER_NAME",
                 "SERVER_PORT",
@@ -982,6 +983,7 @@ class DummyParser:
     version = "1.0"
     command = "GET"
     path = "/"
+    request_uri = "/"
     query = ""
     url_scheme = "http"
     expect_continue = False


### PR DESCRIPTION
This PR adds REQUEST_URI to the WSGI environment, allowing apps to use the raw request path if they need it. My apps use it to distinguish whether slashes are encoded.