### PR TITLE
runner: Fix alignment of --url-prefix

### DIFF
--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -96,7 +96,7 @@ Standard options:
     --url-scheme=STR
         Default wsgi.url_scheme value, default is 'http'.
 
-   --url-prefix=STR
+    --url-prefix=STR
         The ``SCRIPT_NAME`` WSGI environment value.  Setting this to anything
         except the empty string will cause the WSGI ``SCRIPT_NAME`` value to be
         the value passed minus any trailing slashes you add, and it will cause


### PR DESCRIPTION
The help message contained a misaligned option. This fixes it.

Signed-off-by: Felipe Franciosi <felipe@nutanix.com>