### PR TITLE
Bugfix on Windows: OSError is not subscriptable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,12 @@ Next Release
 Bugfix
 ~~~~~~
 
+- In Python 3 ``OSError`` is no longer subscriptable, this caused failures on
+  Windows attempting to loop to find an socket that would work for use in the
+  trigger.
+
+  See https://github.com/Pylons/waitress/pull/361
+
 - Fixed an issue whereby ``BytesIO`` objects were not properly closed, and
   thereby would not get cleaned up until garbage collection would get around to
   it.

--- a/src/waitress/trigger.py
+++ b/src/waitress/trigger.py
@@ -173,7 +173,7 @@ else:  # pragma: no cover
                     w.connect(connect_address)
                     break  # success
                 except OSError as detail:
-                    if detail[0] != errno.WSAEADDRINUSE:
+                    if getattr(detail, "winerror", None) != errno.WSAEADDRINUSE:
                         # "Address already in use" is the only error
                         # I've seen on two WinXP Pro SP2 boxes, under
                         # Pythons 2.3.5 and 2.4.1.


### PR DESCRIPTION
When Waitress fails to launch on Windows due to an issue with the
trigger socket not being ready for connections, we attempt to loop. In
the past this was done by subscripting the OSError and checking to see
if it matched errno.WSAEADDRINUSE, this is no longer possible in newer
verisons of Python.

This is a quick bugfix for a rare case which should no longer happen on
Windows.

Related: https://github.com/Pylons/waitress/issues/354