### PR TITLE
Garden: update supported python versions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,14 +53,14 @@ jobs:
         name: Validate coverage
         steps:
             - uses: actions/checkout@v2
-            - name: Setup python 3.8
+            - name: Setup python 3.10
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: "3.10"
                   architecture: x64
 
             - run: pip install tox
-            - run: tox -e py38,coverage
+            - run: tox -e py310,coverage
     docs:
         runs-on: ubuntu-latest
         name: Build the documentation
@@ -69,7 +69,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: "3.10"
                   architecture: x64
             - run: pip install tox
             - run: tox -e docs
@@ -81,7 +81,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: "3.10"
                   architecture: x64
             - run: pip install tox
             - run: tox -e lint

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Next Release
 ------------
 
+Python Version Support
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Python 3.6 is no longer supported by Waitress
+
+- Python 3.10 is fully supported by Waitress
+
 Bugfix
 ~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Waitress
 
 Waitress is a production-quality pure-Python WSGI server with very acceptable
 performance. It has no dependencies except ones which live in the Python
-standard library. It runs on CPython on Unix and Windows under Python 3.6+. It
-is also known to run on PyPy (version 3.6 compatible) on UNIX. It supports
-HTTP/1.0 and HTTP/1.1.
+standard library. It runs on CPython on Unix and Windows under Python 3.7+. It
+is also known to run on PyPy 3 (version 3.7 compatible python) on UNIX. It
+supports HTTP/1.0 and HTTP/1.1.
 
 For more information, see the "docs" directory of the Waitress package or visit
 https://docs.pylonsproject.org/projects/waitress/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,8 @@ Waitress
 Waitress is meant to be a production-quality pure-Python WSGI server with very
 acceptable performance. It has no dependencies except ones which live in the
 Python standard library. It runs on CPython on Unix and Windows under Python
-3.6+. It is also known to run on PyPy 7.3.2 (PyPy3) on UNIX.  It supports
-HTTP/1.0 and HTTP/1.1.
+3.7+. It is also known to run on PyPy 3 (python version 3.7+) on UNIX.  It
+supports HTTP/1.0 and HTTP/1.1.
 
 
 Extended Documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,10 @@ classifiers =
     License :: OSI Approved :: Zope Public License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent
@@ -37,7 +37,7 @@ maintainer_email = pylons-discuss@googlegroups.com
 package_dir=
     =src
 packages=find:
-python_requires = >=3.6.0
+python_requires = >=3.7.0
 
 [options.entry_points]
 paste.server_runner =

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -102,6 +102,15 @@ class SubprocessTests:
         self.proc.join()
         self.proc.close()
 
+        # The following is for the benefit of PyPy 3, for some reason it is
+        # holding on to some resources way longer than necessary causing tests
+        # to fail with file desctriptor exceeded errors on macOS which defaults
+        # to 256 file desctriptors per process. While we could use ulimit to
+        # increase the limits before running tests, this works as well and
+        # means we don't need to remember to do that.
+        import gc
+        gc.collect()
+
     def assertline(self, line, status, reason, version):
         v, s, r = (x.strip() for x in line.split(None, 2))
         self.assertEqual(s, status.encode("latin-1"))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -98,9 +98,10 @@ class SubprocessTests:
             self.proc.terminate()
         self.sock.close()
         # This give us one FD back ...
-        self.queue.close()
         self.proc.join()
         self.proc.close()
+        self.queue.close()
+        self.queue.join_thread()
 
         # The following is for the benefit of PyPy 3, for some reason it is
         # holding on to some resources way longer than necessary causing tests
@@ -109,6 +110,7 @@ class SubprocessTests:
         # increase the limits before running tests, this works as well and
         # means we don't need to remember to do that.
         import gc
+
         gc.collect()
 
     def assertline(self, line, status, reason, version):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -52,6 +52,7 @@ class FixtureTcpWSGIServer(server.TcpWSGIServer):
 
     def __init__(self, application, queue, **kw):  # pragma: no cover
         # Coverage doesn't see this as it's ran in a separate process.
+        kw["host"] = "127.0.0.1"
         kw["port"] = 0  # Bind to any available port.
         super().__init__(application, **kw)
         host, port = self.socket.getsockname()

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist =
     lint,
-    py36,py37,py38,py39,pypy3,
-    docs,
-    coverage
-isolated_build = True
+    py37,py38,py39,py310,pypy3,
+    coverage,
+    docs
 
 [testenv]
 commands =
     python --version
-    pytest {posargs:}
+    pytest --cov {posargs:}
 extras =
     testing
 setenv =
@@ -25,46 +24,37 @@ deps =
     coverage
 setenv =
     COVERAGE_FILE=.coverage
-depends = py38
-
-[testenv:lint]
-skip_install = True
-commands =
-    black --check --diff .
-    isort --check-only --df src/waitress tests
-    check-manifest
-    # flake8 src/waitress/ tests
-    # build sdist/wheel
-    python -m pep517.build .
-    twine check dist/*
-deps =
-    black
-    check-manifest
-    flake8
-    flake8-bugbear
-    isort
-    pep517
-    readme_renderer
-    twine
 
 [testenv:docs]
 whitelist_externals =
     make
 commands =
-    make -C docs html BUILDDIR={envdir} SPHINXOPTS="-W -E"
+    make -C docs html BUILDDIR={envdir} "SPHINXOPTS=-W -E -D suppress_warnings=ref.term"
 extras =
     docs
 
-[testenv:run-flake8]
+[testenv:lint]
 skip_install = True
 commands =
-    flake8 src/waitress/ tests
+    isort --check-only --df src/waitress tests
+    black --check --diff .
+    check-manifest
+    # flake8 src/waitress/ tests
+    # build sdist/wheel
+    python -m build .
+    twine check dist/*
 deps =
+    black
+    build
+    check-manifest
     flake8
     flake8-bugbear
+    isort
+    readme_renderer
+    twine
 
-[testenv:run-format]
-skip_install = True
+[testenv:format]
+skip_install = true
 commands =
     isort src/waitress tests
     black .
@@ -80,12 +70,12 @@ commands =
     # Make sure we aren't forgetting anything
     check-manifest
     # build sdist/wheel
-    python -m pep517.build .
+    python -m build .
     # Verify all is well
     twine check dist/*
 
 deps =
-    readme_renderer
+    build
     check-manifest
-    pep517
+    readme_renderer
     twine

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,14 @@ envlist =
     py37,py38,py39,py310,pypy3,
     coverage,
     docs
+isolated_build = True
 
 [testenv]
 commands =
     python --version
-    pytest --cov {posargs:}
+    python -mpytest \
+    pypy3: --no-cov \
+        {posargs:}
 extras =
     testing
 setenv =


### PR DESCRIPTION
This updates the supported versions of Python for waitress/updates tox to match, and updates CI to run tests/coverage on newer versions.

Depends on #360 