### PR TITLE
Bugfix: wsgi.file_wrapper should pass-through seek/tell attrs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,13 @@ Python Version Support
 Bugfix
 ~~~~~~
 
+- ``wsgi.file_wrapper`` now sets the ``seekable``, ``seek``, and ``tell`` attributes from
+  the underlying file if the underlying file is seekable. This allows WSGI
+  middleware to implement things like range requests for example
+
+  See https://github.com/Pylons/waitress/issues/359 and
+  https://github.com/Pylons/waitress/pull/363
+
 - In Python 3 ``OSError`` is no longer subscriptable, this caused failures on
   Windows attempting to loop to find an socket that would work for use in the
   trigger.

--- a/src/waitress/buffers.py
+++ b/src/waitress/buffers.py
@@ -145,6 +145,16 @@ class ReadOnlyFileBasedBuffer(FileBasedBuffer):
         self.file = file
         self.block_size = block_size  # for __iter__
 
+        # This is for the benefit of anyone that is attempting to wrap this
+        # wsgi.file_wrapper in a WSGI middleware and wants to seek, this is
+        # useful for instance for support Range requests
+        if _is_seekable(self.file):
+            if hasattr(self.file, "seekable"):
+                self.seekable = self.file.seekable
+
+            self.seek = self.file.seek
+            self.tell = self.file.tell
+
     def prepare(self, size=None):
         if _is_seekable(self.file):
             start_pos = self.file.tell()

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -185,6 +185,8 @@ class TestReadOnlyFileBasedBuffer(unittest.TestCase):
     def test_prepare_not_seekable(self):
         f = KindaFilelike(b"abc")
         inst = self._makeOne(f)
+        self.assertFalse(hasattr(inst, "seek"))
+        self.assertFalse(hasattr(inst, "tell"))
         result = inst.prepare()
         self.assertEqual(result, False)
         self.assertEqual(inst.remain, 0)
@@ -200,6 +202,8 @@ class TestReadOnlyFileBasedBuffer(unittest.TestCase):
     def test_prepare_seekable_closeable(self):
         f = Filelike(b"abc", close=1, tellresults=[0, 10])
         inst = self._makeOne(f)
+        self.assertEqual(inst.seek, f.seek)
+        self.assertEqual(inst.tell, f.tell)
         result = inst.prepare()
         self.assertEqual(result, 10)
         self.assertEqual(inst.remain, 10)


### PR DESCRIPTION
When the application author uses `wsgi.file_wrapper` we want to allow downstream WSGI middleware to seek that file if the underlying file supports it, rather than needing to iterate over the full file to get to the part that the WSGI middleware wants to start at.

Closes #359