### PR TITLE
Set `clear_untrusted_proxy_headers` parameter to `True` by default

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -160,7 +160,7 @@ clear_untrusted_proxy_headers
 
    Default: ``True``
 
-   .. versionchanged:: 2.1.1
+   .. versionchanged:: 2.1.2
       In this version default value is set to ``True`` and deprecation warning
       doesn't show up anymore.
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -158,7 +158,11 @@ clear_untrusted_proxy_headers
    "X-Forwared-For", "X-Forwarded-By", "X-Forwarded-Host", "X-Forwarded-Port",
    "X-Forwarded-Proto") not explicitly allowed by ``trusted_proxy_headers``.
 
-   Default: ``False``
+   Default: ``True``
+
+   .. versionchanged:: 2.1.1
+      In this version default value is set to ``True`` and deprecation warning
+      doesn't show up anymore.
 
    .. versionadded:: 1.2.0
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -175,7 +175,7 @@ class Adjustments:
     # sense to set when you have a trusted_proxy, and you expect the upstream
     # proxy server to filter invalid headers
     log_untrusted_proxy_headers = False
-    
+
     # Changed this parameter to True by default in 2.x
     clear_untrusted_proxy_headers = True
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -95,10 +95,6 @@ class _int_marker(int):
     pass
 
 
-class _bool_marker:
-    pass
-
-
 class Adjustments:
     """This class contains tunable parameters."""
 
@@ -179,10 +175,9 @@ class Adjustments:
     # sense to set when you have a trusted_proxy, and you expect the upstream
     # proxy server to filter invalid headers
     log_untrusted_proxy_headers = False
-
-    # Should waitress clear any proxy headers that are not deemed trusted from
-    # the environ? Change to True by default in 2.x
-    clear_untrusted_proxy_headers = _bool_marker
+    
+    # Changed this parameter to True by default in 2.x
+    clear_untrusted_proxy_headers = True
 
     # default ``wsgi.url_scheme`` value
     url_scheme = "http"
@@ -444,15 +439,6 @@ class Adjustments:
                 DeprecationWarning,
             )
             self.trusted_proxy_headers = {"x-forwarded-proto"}
-
-        if self.clear_untrusted_proxy_headers is _bool_marker:
-            warnings.warn(
-                "In future versions of Waitress clear_untrusted_proxy_headers will be "
-                "set to True by default. You may opt-out by setting this value to "
-                "False, or opt-in explicitly by setting this to True.",
-                DeprecationWarning,
-            )
-            self.clear_untrusted_proxy_headers = False
 
         self.listen = wanted_sockets
 

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -354,20 +354,6 @@ class TestAdjustments(unittest.TestCase):
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
             self.assertIn("Implicitly trusting X-Forwarded-Proto", str(w[0]))
 
-    def test_clear_untrusted_proxy_headers(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.resetwarnings()
-            warnings.simplefilter("always")
-            self._makeOne(
-                trusted_proxy="localhost", trusted_proxy_headers={"x-forwarded-for"}
-            )
-
-            self.assertGreaterEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-            self.assertIn(
-                "clear_untrusted_proxy_headers will be set to True", str(w[0])
-            )
-
     def test_deprecated_send_bytes(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.resetwarnings()


### PR DESCRIPTION
Refs to #330 
I just changed the default value and removed the warning. I also removed the `_bool_maker`, because it was no longer needed. An update has been made in the documentation.