### PR TITLE
Bugfix: header calculation

### DIFF
--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -103,7 +103,7 @@ class HTTPRequestParser:
                 # If the headers have ended, and we also have part of the body
                 # message in data we still want to validate we aren't going
                 # over our limit for received headers.
-                self.header_bytes_received += index
+                self.header_bytes_received = index
                 consumed = datalen - (len(s) - index)
             else:
                 self.header_bytes_received += datalen

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -106,6 +106,18 @@ class TestHTTPRequestParser(unittest.TestCase):
         self.assertTrue(self.parser.completed)
         self.assertTrue(isinstance(self.parser.error, RequestEntityTooLarge))
 
+    def test_received_headers_not_too_large_multiple_chunks(self):
+
+        data = b"GET /foobar HTTP/8.4\r\nX-Foo: 1\r\n"
+        data2 = b"X-Foo-Other: 3\r\n\r\n"
+        self.parser.adj.max_request_header_size = len(data) + len(data2) + 1
+        result = self.parser.received(data)
+        self.assertEqual(result, 32)
+        result = self.parser.received(data2)
+        self.assertEqual(result, 18)
+        self.assertTrue(self.parser.completed)
+        self.assertFalse(self.parser.error)
+
     def test_received_headers_too_large(self):
 
         self.parser.adj.max_request_header_size = 2


### PR DESCRIPTION
When receiving the headers in multiple packets the calculation for how big the headers are so far is wrong/invalid. This leads to issues whereby waitress would incorrectly suggest the headers were too large when they were not.

Closes #371