### PR TITLE
Bugfix: Retry if a thread closes a socket before we select() on it

### DIFF
--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -426,7 +426,7 @@ class dispatcher:
         else:
             return conn, addr
 
-    def send(self, data):
+    def send(self, data, do_close=True):
         try:
             result = self.socket.send(data)
             return result
@@ -434,7 +434,8 @@ class dispatcher:
             if why.args[0] == EWOULDBLOCK:
                 return 0
             elif why.args[0] in _DISCONNECTED:
-                self.handle_close()
+                if do_close:
+                    self.handle_close()
                 return 0
             else:
                 raise

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -376,7 +376,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.total_outbufs_len = len(inst.outbufs[0])
         inst.adj.send_bytes = 1
         inst.adj.outbuf_high_watermark = 2
-        sock.send = lambda x: False
+        sock.send = lambda x, do_close=True: False
         inst.will_close = False
         inst.last_activity = 0
         result = inst.handle_write()
@@ -453,7 +453,7 @@ class TestHTTPChannel(unittest.TestCase):
 
         buf = DummyHugeOutbuffer()
         inst.outbufs = [buf]
-        inst.send = lambda *arg: 0
+        inst.send = lambda *arg, do_close: 0
         result = inst._flush_some()
         # we are testing that _flush_some doesn't raise an OverflowError
         # when one of its outbufs has a __len__ that returns gt sys.maxint


### PR DESCRIPTION
There's a potential issue whereby a thread attempts to send data, but the socket is closed on the other end, and the thread shuts the socket down.

This may however happen while the file descriptors are being put together before being passed to `select()` which will then fail as that file descriptor is no longer valid.

Instead we loop until we have called `select()` successfully, while checking to see if the file descriptors has changed since we started the poll.

If the map of file descriptors has not changed, and yet we get an `errno` that is a bad file descriptor, we will just raise it and kill the main loop.

Closes #374