### PR TITLE
Remove `__nonzero__` methods

### DIFF
--- a/src/waitress/buffers.py
+++ b/src/waitress/buffers.py
@@ -44,10 +44,8 @@ class FileBasedBuffer:
     def __len__(self):
         return self.remain
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
-
-    __bool__ = __nonzero__  # py3
 
     def append(self, s):
         file = self.file
@@ -224,12 +222,10 @@ class OverflowableBuffer:
         else:
             return self.strbuf.__len__()
 
-    def __nonzero__(self):
+    def __bool__(self):
         # use self.__len__ rather than len(self) FBO of not getting
         # OverflowError on Python 2
         return self.__len__() > 0
-
-    __bool__ = __nonzero__  # py3
 
     def _create_buffer(self):
         strbuf = self.strbuf


### PR DESCRIPTION
`__nonzero__` is not used in python3.
And since [`setup.py` declares](https://github.com/Pylons/waitress/blob/ec0e1655c4bba1411bf65dc9f0f03fdfb0e4fc74/setup.cfg#L40) python3.7 support only, I think it is safe to remove these methods.

I found this while working on `typeshed` types for this project 🙂 