### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -90,7 +90,7 @@ Common options:
         --listen=[::1]:8080
         --listen=*:8080
 
-    This option may be used multiple times to listen on multipe sockets.
+    This option may be used multiple times to listen on multiple sockets.
     A wildcard for the hostname is also supported and will bind to both
     IPv4/IPv6 depending on whether they are enabled or disabled.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,7 +57,7 @@ Using ``host`` and ``port`` is also supported:
     host = 127.0.0.1
     port = 8080
 
-The :term:`PasteDeploy` syntax for UNIX domain sockets is analagous:
+The :term:`PasteDeploy` syntax for UNIX domain sockets is analogous:
 
 .. code-block:: ini
 

--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -126,7 +126,7 @@ class HTTPRequestParser:
                 # Header finished.
                 header_plus = s[:index]
 
-                # Remove preceeding blank lines. This is suggested by
+                # Remove preceding blank lines. This is suggested by
                 # https://tools.ietf.org/html/rfc7230#section-3.5 to support
                 # clients sending an extra CR LF after another request when
                 # using HTTP pipelining

--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -134,7 +134,7 @@ def create_server(
 
 # This class is only ever used if we have multiple listen sockets. It allows
 # the serve() API to call .run() which starts the wasyncore loop, and catches
-# SystemExit/KeyboardInterrupt so that it can atempt to cleanly shut down.
+# SystemExit/KeyboardInterrupt so that it can attempt to cleanly shut down.
 class MultiSocketServer:
     asyncore = wasyncore  # test shim
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -105,8 +105,8 @@ class SubprocessTests:
 
         # The following is for the benefit of PyPy 3, for some reason it is
         # holding on to some resources way longer than necessary causing tests
-        # to fail with file desctriptor exceeded errors on macOS which defaults
-        # to 256 file desctriptors per process. While we could use ulimit to
+        # to fail with file descriptor exceeded errors on macOS which defaults
+        # to 256 file descriptors per process. While we could use ulimit to
         # increase the limits before running tests, this works as well and
         # means we don't need to remember to do that.
         import gc


### PR DESCRIPTION
There are small typos in:
- docs/runner.rst
- docs/usage.rst
- src/waitress/parser.py
- src/waitress/server.py
- tests/test_functional.py

Fixes:
- Should read `preceding` rather than `preceeding`.
- Should read `multiple` rather than `multipe`.
- Should read `descriptors` rather than `desctriptors`.
- Should read `descriptor` rather than `desctriptor`.
- Should read `attempt` rather than `atempt`.
- Should read `analogous` rather than `analagous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md