### PR TITLE
Including `waitress.channel` in request environment variable

### DIFF
--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -551,6 +551,7 @@ class WSGITask(Task):
             "wsgi.input": request.get_body_stream(),
             "wsgi.file_wrapper": ReadOnlyFileBasedBuffer,
             "wsgi.input_terminated": True,  # wsgi.input is EOF terminated
+            "waitress.channel": channel,
         }
 
         for key, value in dict(request.headers).items():


### PR DESCRIPTION
Including channel, which contains the socket, into the request environment variable for graceful handling of sockets.

Background: We want to produce some custom errors like "connection-reset" in the unit tests via waitress and for it we need a graceful way to explicitly close the request's socket, which can be achieved using 'channel.handle_close()' .
Earlier we were using Gunicorn and in it we were able to achieve same functionality using 'gunicorn.socket' present in it's request environment variable. Now we are planning to replace it with waitress.