### PR TITLE
Metrics collector with queue length & wait time reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 coverage.xml
 docs/_themes
 docs/_build
+*.swp

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -133,6 +133,7 @@ class Adjustments:
         ("sockets", as_socket_list),
         ("channel_request_lookahead", int),
         ("server_name", str),
+        ("metrics_collector", lambda x: x),
     )
 
     _param_map = dict(_params)
@@ -288,6 +289,9 @@ class Adjustments:
     # only ever used if the remote client sent a request without a Host header
     # (or when using the Proxy settings, without forwarding a Host header)
     server_name = "waitress.invalid"
+
+    # Metrics collector. This allow to provide the listener that collects metrics
+    metrics_collector = None
 
     def __init__(self, **kw):
 

--- a/src/waitress/observability.py
+++ b/src/waitress/observability.py
@@ -1,0 +1,25 @@
+##############################################################################
+#
+# Copyright (c) 2001, 2002 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Interfaces for metrics collection
+"""
+
+from typing import Protocol
+
+
+class TasksMetricsCollector(Protocol):
+    def report_queue_length(self, lenght):
+        ...  # pragma: no cover
+
+    def report_task_wait_time(self, wait_time_ns):
+        ...  # pragma: no cover

--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -34,7 +34,7 @@ def create_server(
     _start=True,  # test shim
     _sock=None,  # test shim
     _dispatcher=None,  # test shim
-    **kw  # adjustments
+    **kw,  # adjustments
 ):
     """
     if __name__ == '__main__':
@@ -53,7 +53,7 @@ def create_server(
 
     dispatcher = _dispatcher
     if dispatcher is None:
-        dispatcher = ThreadedTaskDispatcher()
+        dispatcher = ThreadedTaskDispatcher(metrics_collector=adj.metrics_collector)
         dispatcher.set_thread_count(adj.threads)
 
     if adj.unix_socket and hasattr(socket, "AF_UNIX"):
@@ -194,7 +194,7 @@ class BaseWSGIServer(wasyncore.dispatcher):
         adj=None,  # adjustments
         sockinfo=None,  # opaque object
         bind_socket=True,
-        **kw
+        **kw,
     ):
         if adj is None:
             adj = Adjustments(**kw)
@@ -388,7 +388,7 @@ if hasattr(socket, "AF_UNIX"):
             dispatcher=None,  # dispatcher
             adj=None,  # adjustments
             sockinfo=None,  # opaque object
-            **kw
+            **kw,
         ):
             if sockinfo is None:
                 sockinfo = (socket.AF_UNIX, socket.SOCK_STREAM, None, None)

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -107,6 +107,7 @@ class TestAdjustments(unittest.TestCase):
         return Adjustments(**kw)
 
     def test_goodvars(self):
+        test_metrics_collector = object()
         inst = self._makeOne(
             host="localhost",
             port="8080",
@@ -135,6 +136,7 @@ class TestAdjustments(unittest.TestCase):
             url_prefix="///foo/",
             ipv4=True,
             ipv6=False,
+            metrics_collector=test_metrics_collector,
         )
 
         self.assertEqual(inst.host, "localhost")
@@ -164,6 +166,7 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.url_prefix, "/foo")
         self.assertEqual(inst.ipv4, True)
         self.assertEqual(inst.ipv6, False)
+        self.assertEqual(inst.metrics_collector, test_metrics_collector)
 
         bind_pairs = [
             sockaddr[:2]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ class TestWSGIServer(unittest.TestCase):
         _start=True,
         _sock=None,
         _server=None,
+        metrics_collector=None,
     ):
         from waitress.server import create_server
 
@@ -25,6 +26,7 @@ class TestWSGIServer(unittest.TestCase):
             host=host,
             port=port,
             map=map,
+            metrics_collector=metrics_collector,
             _dispatcher=_dispatcher,
             _start=_start,
             _sock=_sock,
@@ -108,6 +110,16 @@ class TestWSGIServer(unittest.TestCase):
         self.assertEqual(
             inst.task_dispatcher.__class__.__name__, "ThreadedTaskDispatcher"
         )
+
+    def test_ctor_passes_metrics_collector_to_dispatcher(self):
+        from waitress.observability import TasksMetricsCollector
+
+        class DummyMetricsCollector(TasksMetricsCollector):
+            pass
+
+        metrics_collector = DummyMetricsCollector()
+        inst = self._makeOne(_start=False, map={}, metrics_collector=metrics_collector)
+        self.assertEqual(inst.task_dispatcher.metrics_collector, metrics_collector)
 
     def test_ctor_start_false(self):
         inst = self._makeOneWithMap(_start=False)


### PR DESCRIPTION
This adds an extension point that allows to plug in metrics collection for the tasks queue.