### PR TITLE
ensure we don't loop trying to write to a channel thats not connected (fix 100% CPU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 coverage.xml
 docs/_themes
 docs/_build
+.venv/

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -86,7 +86,7 @@ class HTTPChannel(wasyncore.dispatcher):
         # the channel (possibly by our server maintenance logic), run
         # handle_write
 
-        return self.total_outbufs_len or self.will_close or self.close_when_flushed
+        return self.connected and (self.total_outbufs_len or self.will_close or self.close_when_flushed)
 
     def handle_write(self):
         # Precondition: there's data in the out buffer to be sent, or
@@ -95,8 +95,8 @@ class HTTPChannel(wasyncore.dispatcher):
         if not self.connected:
             # we dont want to close the channel twice
             # But we shouldn't be written to if we really are closed so unregister from loop
-            self.del_channel()
-
+            # self.del_channel()
+            #self.close_when_flushed = True
             return
 
         # try to flush any pending output

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -95,8 +95,9 @@ class HTTPChannel(wasyncore.dispatcher):
         # Precondition: there's data in the out buffer to be sent, or
         # there's a pending will_close request
 
-        if not self.connected and not self.close_when_flushed:
-            # we dont want to close the channel twice
+        if not self.connected and not (self.will_close or self.close_when_flushed):
+            # we dont want to close the channel twice.
+            # but we need let the channel close if it's marked to close
             return
 
         # try to flush any pending output

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -94,6 +94,8 @@ class HTTPChannel(wasyncore.dispatcher):
 
         if not self.connected:
             # we dont want to close the channel twice
+            # But we shouldn't be written to if we really are closed so unregister from loop
+            self.del_channel()
 
             return
 

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -45,6 +45,7 @@ class HTTPChannel(wasyncore.dispatcher):
     last_activity = 0  # Time of last activity
     will_close = False  # set to True to close the socket.
     close_when_flushed = False  # set to True to close the socket when flushed
+    closed = False  # set to True when closed not just due to being disconnected at the start
     sent_continue = False  # used as a latch after sending 100 continue
     total_outbufs_len = 0  # total bytes ready to send
     current_outbuf_count = 0  # total bytes written to current outbuf
@@ -95,7 +96,7 @@ class HTTPChannel(wasyncore.dispatcher):
         # Precondition: there's data in the out buffer to be sent, or
         # there's a pending will_close request
 
-        if not self.connected and not (self.will_close or self.close_when_flushed):
+        if self.closed:
             # we dont want to close the channel twice.
             # but we need let the channel close if it's marked to close
             return
@@ -316,6 +317,7 @@ class HTTPChannel(wasyncore.dispatcher):
             self.total_outbufs_len = 0
             self.connected = False
             self.outbuf_lock.notify()
+        self.closed = True
         wasyncore.dispatcher.close(self)
 
     def add_channel(self, map=None):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -772,16 +772,6 @@ class TestHTTPChannel(unittest.TestCase):
         inst.cancel()
         self.assertEqual(inst.requests, [])
 
-    def test_shutdown_quick_loop(self):
-        inst, sock, map = self._makeOneWithMap(sock_shutdown=True)
-        # if sock.shutdown(socket.SHUT_RD) creating the dispatcher we will get a connected == False
-        self.assertRaises(OSError, sock.getpeername)
-        self.assertFalse(inst.connected)
-        self.assertTrue(inst._map)  # still processing
-        # inst.handle_write()   # but still half connected so select will say it can write
-        # self.assertFalse(inst._map, "channel should be removed so we don't loop and select socket again")
-        self.assertTrue(all(not c.writable() for c in inst._map.values()), "if our channel is writable we can get into a loop")
-        # self.assertTrue(sock.closed, "Should be close the channel instead?")
 
 class TestHTTPChannelLookahead(TestHTTPChannel):
     def app_check_disconnect(self, environ, start_response):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -67,7 +67,17 @@ class TestHTTPChannel(unittest.TestCase):
     def test_handle_write_not_connected(self):
         inst, sock, map = self._makeOneWithMap()
         inst.connected = False
+        # TODO: handle_write never returns anything anyway
         self.assertFalse(inst.handle_write())
+
+    def test_handle_write_not_connected_but_will_close(self):
+        inst, sock, map = self._makeOneWithMap()
+        inst.connected = False
+        inst.will_close = True
+        # https://github.com/Pylons/waitress/issues/418
+        # Ensure we actually handle_close even if not connected
+        self.assertFalse(inst.handle_write())
+        self.assertEqual(len(map), 0)
 
     def test_handle_write_with_requests(self):
         inst, sock, map = self._makeOneWithMap()

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -778,8 +778,9 @@ class TestHTTPChannel(unittest.TestCase):
         self.assertRaises(OSError, sock.getpeername)
         self.assertFalse(inst.connected)
         self.assertTrue(inst._map)  # still processing
-        inst.handle_write()   # but still half connected so select will say it can write
-        self.assertFalse(inst._map, "channel should be removed so we don't loop and select socket again")
+        # inst.handle_write()   # but still half connected so select will say it can write
+        # self.assertFalse(inst._map, "channel should be removed so we don't loop and select socket again")
+        self.assertTrue(all(not c.writable() for c in inst._map.values()), "if our channel is writable we can get into a loop")
         # self.assertTrue(sock.closed, "Should be close the channel instead?")
 
 class TestHTTPChannelLookahead(TestHTTPChannel):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -443,7 +443,7 @@ class TestWSGIServer(unittest.TestCase):
         server_run(5)
 
         # self.assertEqual(channel.count_wouldblock, 1, "we need data left to send to be in a loop")
-        self.assertEqual(channel.count_writes, 0, "ensure we aren't in a loop trying to write but can't")
+        self.assertEqual(channel.count_writes > 1, "ensure we aren't in a loop trying to write but can't")
         self.assertEqual(channel.count_close, 0, "but also this connection never gets closed")
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -368,7 +368,7 @@ class TestWSGIServer(unittest.TestCase):
             def __init__(self, server, sock, addr, adj, map=None):
                 self.count_writes = self.count_close = self.count_wouldblock = 0
                 # sleep(5)
-                #client.shutdown(socket.SHUT_RDWR)  # has to be here to reproduce. just RD or WR won't work
+                # client.shutdown(socket.SHUT_RDWR)  # has to be here to reproduce. just RD or WR won't work
                 #client.recv(1)
                 client.close()  # simulate race condition where close happens between accept adn getpeername
                 # sleep(1)  # has to be at least 65s to reproduce
@@ -438,7 +438,7 @@ class TestWSGIServer(unittest.TestCase):
         self.assertRaises(Exception, channel.socket.getpeername)
         self.assertFalse(channel.connected, "race condition means our socket is marked not connected")
 
-        server_run(1)
+        server_run(5)
         channel.service()  # Our error request sets close_after_flushed
         server_run(5)
 


### PR DESCRIPTION
fixes #418 

This fixes a race condition where a quick forced socket close will make getpeername to fail and connected == False. If the request then has an error close_after_flush is set and this will result in a 100% CPU loop.
This wiil ensure the channel is still closed in this case.

TODO:
- [x] add some more specific tests for double close 
- [x] test for closing a error request thats not connected
- [x] test for maintainance not cleaning up an unconnected task
- [ ] change the fix to only prevent write specifically when already closed, not when not connected
- [ ] undo fix that closes if getpeername fails.
