### PR TITLE
Avoid closing connections when `HEAD` requests have a content length

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -590,7 +590,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(inst.close_on_finish, True)
         self.assertEqual(len(inst.logger.logged), 1)
 
-    def test_execute_app_do_not_warn_on_head(self):
+    def test_execute_app_head_with_content_length(self):
         def app(environ, start_response):
             start_response("200 OK", [("Content-Length", "3")])
             return [b""]
@@ -600,7 +600,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertEqual(inst.close_on_finish, False)
         self.assertEqual(len(inst.logger.logged), 0)
 
     def test_execute_app_without_body_204_logged(self):


### PR DESCRIPTION
Closes https://github.com/Pylons/waitress/issues/427

When a WSGI application does not return sufficient content to satisfy the attached `Content-Length` header, the connection is closed to prevent the client from needlessly waiting. However, HTTP HEAD requests can set a `Content-Length` header without any content in the body. #7 removed a _warning_ that was incorrectly displayed when this occurs, but the connection was still being closed. As demonstrated in #427, this abrupt close can cause client-side failures. Here, the connection is no longer closed for HEAD requests with `Content-Length` set, which resolves the linked issue.