### PR TITLE
Stop stripping \xa0 and \x85 from the beginning and end of header values

### DIFF
--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -557,7 +557,7 @@ class WSGITask(Task):
         }
 
         for key, value in dict(request.headers).items():
-            value = value.strip()
+            value = value.strip(" \t")
             mykey = rename_headers.get(key, None)
             if mykey is None:
                 mykey = "HTTP_" + key


### PR DESCRIPTION
Previously, Waitress stripped `\xa0` and `\x85` from the sides of header values before inserting them into the `environ` dict. Since those bytes are allowed within header values, this could potentially cause data corruption. This patch removes the offending call to `str.strip`.