### PR TITLE
Bugfix: Don't strip whitespace from values before inserting into environ

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+3.0.1 (unreleased)
+------------------
+
+- No longer strip the header values before passing them to the WSGI environ.
+  See https://github.com/Pylons/waitress/pull/434 and
+  https://github.com/Pylons/waitress/issues/432
+
 3.0.0 (2024-02-04)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = waitress
-version = 3.0.0
+version = 3.0.1
 description = Waitress WSGI server
 long_description = file: README.rst, CHANGES.txt
 long_description_content_type = text/x-rst

--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -557,7 +557,6 @@ class WSGITask(Task):
         }
 
         for key, value in dict(request.headers).items():
-            value = value.strip()
             mykey = rename_headers.get(key, None)
             if mykey is None:
                 mykey = "HTTP_" + key

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -384,6 +384,11 @@ class TestHTTPRequestParser(unittest.TestCase):
         else:  # pragma: nocover
             self.assertTrue(False)
 
+    def test_parse_header_other_whitespace(self):
+        data = b"GET /foobar HTTP/1.1\r\nfoo: \xa0something\x85\r\n"
+        self.parser.parse_header(data)
+        self.assertEqual(self.parser.headers["FOO"], "\xa0something\x85")
+
     def test_parse_header_empty(self):
         data = b"GET /foobar HTTP/1.1\r\nfoo: bar\r\nempty:\r\n"
         self.parser.parse_header(data)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -776,7 +776,7 @@ class TestWSGITask(unittest.TestCase):
         request.headers = {
             "CONTENT_TYPE": "abc",
             "CONTENT_LENGTH": "10",
-            "X_FOO": "BAR",
+            "X_FOO": "\xa0BAR\x85",
             "CONNECTION": "close",
         }
         request.query = "abc"
@@ -830,7 +830,8 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(environ["REMOTE_PORT"], "39830")
         self.assertEqual(environ["CONTENT_TYPE"], "abc")
         self.assertEqual(environ["CONTENT_LENGTH"], "10")
-        self.assertEqual(environ["HTTP_X_FOO"], "BAR")
+        # Make sure we don't strip non RFC compliant whitespace
+        self.assertEqual(environ["HTTP_X_FOO"], "\xa0BAR\x85")
         self.assertEqual(environ["wsgi.version"], (1, 0))
         self.assertEqual(environ["wsgi.url_scheme"], "http")
         self.assertEqual(environ["wsgi.errors"], sys.stderr)


### PR DESCRIPTION
This fixes a small bug where the value of the header would get stripped when inserted into the environ so it no longer matched.

Closes #432