### PR TITLE
Remove race condition when creating new HTTPChannel

### DIFF
--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -91,13 +91,7 @@ class HTTPChannel(wasyncore.dispatcher):
         # Precondition: there's data in the out buffer to be sent, or
         # there's a pending will_close request
 
-        if not self.connected:
-            # we dont want to close the channel twice
-
-            return
-
         # try to flush any pending output
-
         if not self.requests:
             # 1. There are no running tasks, so we don't need to try to lock
             #    the outbuf before sending

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -67,8 +67,7 @@ class HTTPChannel(wasyncore.dispatcher):
         self.outbuf_lock = threading.Condition()
 
         wasyncore.dispatcher.__init__(self, sock, map=map)
-
-        # Don't let wasyncore.dispatcher throttle self.addr on us.
+        self.connected = True
         self.addr = addr
         self.requests = []
 

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -297,22 +297,6 @@ class dispatcher:
             # get a socket from a blocking source.
             sock.setblocking(0)
             self.set_socket(sock, map)
-            self.connected = True
-            # The constructor no longer requires that the socket
-            # passed be connected.
-            try:
-                self.addr = sock.getpeername()
-            except OSError as err:
-                if err.args[0] in (ENOTCONN, EINVAL):
-                    # To handle the case where we got an unconnected
-                    # socket.
-                    self.connected = False
-                else:
-                    # The socket is broken in some unknown way, alert
-                    # the user and remove it from the map (to prevent
-                    # polling of broken sockets).
-                    self.del_channel(map)
-                    raise
         else:
             self.socket = None
 

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -436,6 +436,8 @@ class dispatcher:
                 if why.args[0] not in (ENOTCONN, EBADF):
                     raise
 
+            self.socket = None
+
     # log and log_info may be overridden to provide more sophisticated
     # logging and warning methods. In general, log is for 'hit' logging
     # and 'log_info' is for informational, warning and error logging.
@@ -486,7 +488,11 @@ class dispatcher:
         # handle_expt_event() is called if there might be an error on the
         # socket, or if there is OOB data
         # check for the error condition first
-        err = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        err = (
+            self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+            if self.socket is not None
+            else 1
+        )
         if err != 0:
             # we can get here when select.select() says that there is an
             # exceptional condition on the socket

--- a/tests/test_wasyncore.py
+++ b/tests/test_wasyncore.py
@@ -1454,17 +1454,6 @@ class Test_dispatcher(unittest.TestCase):
 
         return dispatcher(sock=sock, map=map)
 
-    def test_unexpected_getpeername_exc(self):
-        sock = dummysocket()
-
-        def getpeername():
-            raise OSError(errno.EBADF)
-
-        map = {}
-        sock.getpeername = getpeername
-        self.assertRaises(socket.error, self._makeOne, sock=sock, map=map)
-        self.assertEqual(map, {})
-
     def test___repr__accepting(self):
         sock = dummysocket()
         map = {}


### PR DESCRIPTION
When we `accept()` a connection we get the remote address and we pass it to `HTTPChannel`, then in `wasyncore.dispatcher` we were calling `getpeername()` again to get the same remote address that we already had.

This would cause an issue if the remote client had sent data, but closed the connection before `getpeername()` because the `wasyncore.dispatcher` would set the channel to no longer being connected.

Further down the line this would cause issues whereby `handle_write` would loop over and over because it would mark itself as selectable but the socket would never actually get torn down.

Closes #418
Supersedes #419 