### PR TITLE
Trying to refactor CLI arguments parsing in order to support required, non-positional `--app` argument

### DIFF
--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -14,11 +14,11 @@ underscores, ``waitress-serve`` uses hyphens. Thus::
 
     import myapp
 
-    waitress.serve(myapp.wsgifunc, port=8041, url_scheme='https')
+    waitress.serve(app=myapp.wsgifunc, port=8041, url_scheme='https')
 
 Is equivalent to::
 
-    waitress-serve --port=8041 --url-scheme=https myapp:wsgifunc
+    waitress-serve --app=myapp:wsgifunc --port=8041 --url-scheme=https
 
 The full argument list is :ref:`given below <invocation>`.
 
@@ -47,7 +47,7 @@ A number of frameworks, *web.py* being an example, have factory methods on
 their application objects that return usable WSGI functions when called. For
 cases like these, ``waitress-serve`` has the ``--call`` flag. Thus::
 
-    waitress-serve --call myapp.mymodule.app.wsgi_factory
+    waitress-serve --app=myapp.mymodule.app.wsgi_factory --call
 
 Would load the ``myapp.mymodule`` module, and call ``app.wsgi_factory`` to get
 a WSGI application function to be passed to ``waitress.server``.
@@ -64,7 +64,12 @@ Invocation
 
 Usage::
 
-    waitress-serve [OPTS] MODULE:OBJECT
+    waitress-serve [OPTS] --app=MODULE:OBJECT
+
+Required options:
+
+``--app``
+    Specify WSGI application to run.
 
 Common options:
 

--- a/src/waitress/__init__.py
+++ b/src/waitress/__init__.py
@@ -3,14 +3,14 @@ import logging
 from waitress.server import create_server
 
 
-def serve(app, **kw):
+def serve(app, opts, **kw):
     _server = kw.pop("_server", create_server)  # test shim
     _quiet = kw.pop("_quiet", False)  # test shim
     _profile = kw.pop("_profile", False)  # test shim
     if not _quiet:  # pragma: no cover
         # idempotent if logging has already been set up
         logging.basicConfig()
-    server = _server(app, **kw)
+    server = _server(app, opts, **kw)
     if not _quiet:  # pragma: no cover
         server.print_listen("Serving on http://{}:{}")
     if _profile:  # pragma: no cover
@@ -20,7 +20,7 @@ def serve(app, **kw):
 
 
 def serve_paste(app, global_conf, **kw):
-    serve(app, **kw)
+    serve(app, {}, **kw)
     return 0
 
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -289,7 +289,7 @@ class Adjustments:
     # (or when using the Proxy settings, without forwarding a Host header)
     server_name = "waitress.invalid"
 
-    def __init__(self, **kw):
+    def __init__(self, opts, **kw):
         if "listen" in kw and ("host" in kw or "port" in kw):
             raise ValueError("host or port may not be set if listen is set.")
 
@@ -312,6 +312,12 @@ class Adjustments:
             warnings.warn(
                 "send_bytes will be removed in a future release", DeprecationWarning
             )
+
+        # opts are already validated, so that we set them as is
+        for k, v in opts.items():
+            if k not in self._param_map:
+                raise ValueError("Unknown adjustment %r" % k)
+            setattr(self, k, v)
 
         for k, v in kw.items():
             if k not in self._param_map:
@@ -346,7 +352,10 @@ class Adjustments:
                 if "]" in port:  # pragma: nocover
                     (host, port) = (i, str(self.port))
             else:
-                (host, port) = (i, str(self.port))
+                if isinstance(i, tuple):
+                    host, port = i
+                else:
+                    host, port = (i, str(self.port))
 
             if WIN:  # pragma: no cover
                 try:

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -187,6 +187,28 @@ Tuning options:
 
 """
 
+RUNNER_PATTERN = re.compile(
+    r"""
+    ^
+    (?P<module>
+        [a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*
+    )
+    :
+    (?P<object>
+        [a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*
+    )
+    $
+    """,
+    re.I | re.X,
+)
+
+
+def match(obj_name):
+    matches = RUNNER_PATTERN.match(obj_name)
+    if not matches:
+        raise ValueError(f"Malformed application '{obj_name}'")
+    return matches.group("module"), matches.group("object")
+
 
 def resolve(module_name, object_name):
     """Resolve a named object in a module."""

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -345,7 +345,7 @@ client.
 Default is 'no'.""",
     )
 
-    args = parser.parse_args(argv)
+    args = parser.parse_args(argv[1:])
 
     """Command line runner."""
 

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -11,10 +11,9 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Command line runner.
-"""
-
-
+"""Command line runner."""
+import warnings
+import re
 import getopt
 import logging
 import operator as op
@@ -26,166 +25,10 @@ from argparse import ArgumentParser, BooleanOptionalAction
 from dataclasses import dataclass
 from ipaddress import ip_address
 from urllib.parse import urlparse
-
+import importlib
 from waitress import serve
 from waitress.adjustments import Adjustments
 from waitress.utilities import logger
-
-HELP = """\
-Usage:
-
-    {0} --app=MODULE:OBJECT [OPTS]
-
-Standard options:
-
-    --app=MODULE:OBJECT
-        Specify WSGI application to run. Required. Can be passed at any position.
-
-    --help
-        Show this information.
-
-    --call
-        Call the given object to get the WSGI application.
-
-    --host=ADDR
-        Hostname or IP address on which to listen, default is '0.0.0.0',
-        which means "all IP addresses on this host".
-
-        Note: May not be used together with --listen
-
-    --port=PORT
-        TCP port on which to listen, default is '8080'
-
-        Note: May not be used together with --listen
-
-    --listen=ip:port
-        Tell waitress to listen on an ip port combination.
-
-        Example:
-
-            --listen=127.0.0.1:8080
-            --listen=[::1]:8080
-            --listen=*:8080
-
-        This option may be used multiple times to listen on multiple sockets.
-        A wildcard for the hostname is also supported and will bind to both
-        IPv4/IPv6 depending on whether they are enabled or disabled.
-
-    --[no-]ipv4
-        Toggle on/off IPv4 support.
-
-        Example:
-
-            --no-ipv4
-
-        This will disable IPv4 socket support. This affects wildcard matching
-        when generating the list of sockets.
-
-    --[no-]ipv6
-        Toggle on/off IPv6 support.
-
-        Example:
-
-            --no-ipv6
-
-        This will turn on IPv6 socket support. This affects wildcard matching
-        when generating a list of sockets.
-
-    --unix-socket=PATH
-        Path of Unix socket. If a socket path is specified, a Unix domain
-        socket is made instead of the usual inet domain socket.
-
-        Not available on Windows.
-
-    --unix-socket-perms=PERMS
-        Octal permissions to use for the Unix domain socket, default is
-        '600'.
-
-    --url-scheme=STR
-        Default wsgi.url_scheme value, default is 'http'.
-
-    --url-prefix=STR
-        The ``SCRIPT_NAME`` WSGI environment value.  Setting this to anything
-        except the empty string will cause the WSGI ``SCRIPT_NAME`` value to be
-        the value passed minus any trailing slashes you add, and it will cause
-        the ``PATH_INFO`` of any request which is prefixed with this value to
-        be stripped of the prefix.  Default is the empty string.
-
-    --ident=STR
-        Server identity used in the 'Server' header in responses. Default
-        is 'waitress'.
-
-Tuning options:
-
-    --threads=INT
-        Number of threads used to process application logic, default is 4.
-
-    --backlog=INT
-        Connection backlog for the server. Default is 1024.
-
-    --recv-bytes=INT
-        Number of bytes to request when calling socket.recv(). Default is
-        8192.
-
-    --send-bytes=INT
-        Number of bytes to send to socket.send(). Default is 18000.
-        Multiples of 9000 should avoid partly-filled TCP packets.
-
-    --outbuf-overflow=INT
-        A temporary file should be created if the pending output is larger
-        than this. Default is 1048576 (1MB).
-
-    --outbuf-high-watermark=INT
-        The app_iter will pause when pending output is larger than this value
-        and will resume once enough data is written to the socket to fall below
-        this threshold. Default is 16777216 (16MB).
-
-    --inbuf-overflow=INT
-        A temporary file should be created if the pending input is larger
-        than this. Default is 524288 (512KB).
-
-    --connection-limit=INT
-        Stop creating new channels if too many are already active.
-        Default is 100.
-
-    --cleanup-interval=INT
-        Minimum seconds between cleaning up inactive channels. Default
-        is 30. See '--channel-timeout'.
-
-    --channel-timeout=INT
-        Maximum number of seconds to leave inactive connections open.
-        Default is 120. 'Inactive' is defined as 'has received no data
-        from the client and has sent no data to the client'.
-
-    --[no-]log-socket-errors
-        Toggle whether premature client disconnect tracebacks ought to be
-        logged. On by default.
-
-    --max-request-header-size=INT
-        Maximum size of all request headers combined. Default is 262144
-        (256KB).
-
-    --max-request-body-size=INT
-        Maximum size of request body. Default is 1073741824 (1GB).
-
-    --[no-]expose-tracebacks
-        Toggle whether to expose tracebacks of unhandled exceptions to the
-        client. Off by default.
-
-    --asyncore-loop-timeout=INT
-        The timeout value in seconds passed to asyncore.loop(). Default is 1.
-
-    --asyncore-use-poll
-        The use_poll argument passed to ``asyncore.loop()``. Helps overcome
-        open file descriptors limit. Default is False.
-
-    --channel-request-lookahead=INT
-        Allows channels to stay readable and buffer more requests up to the
-        given maximum even if a request is already being processed. This allows
-        detecting if a client closed the connection while its request is being
-        processed. Default is 0.
-
-"""
 
 RUNNER_PATTERN = re.compile(
     r"""
@@ -205,28 +48,15 @@ RUNNER_PATTERN = re.compile(
 
 def match(obj_name):
     matches = RUNNER_PATTERN.match(obj_name)
+
     if not matches:
         raise ValueError(f"Malformed application '{obj_name}'")
+
     return matches.group("module"), matches.group("object")
 
 
 def resolve(module_name, object_name):
-    """Resolve a named object in a module."""
-    # We cast each segments due to an issue that has been found to manifest
-    # in Python 2.6.6, but not 2.6.8, and may affect other revisions of Python
-    # 2.6 and 2.7, whereby ``__import__`` chokes if the list passed in the
-    # ``fromlist`` argument are unicode strings rather than 8-bit strings.
-    # The error triggered is "TypeError: Item in ``fromlist '' not a string".
-    # My guess is that this was fixed by checking against ``basestring``
-    # rather than ``str`` sometime between the release of 2.6.6 and 2.6.8,
-    # but I've yet to go over the commits. I know, however, that the NEWS
-    # file makes no mention of such a change to the behaviour of
-    # ``__import__``.
-    segments = [str(segment) for segment in object_name.split(".")]
-    obj = __import__(module_name, fromlist=segments[:1])
-    for segment in segments:
-        obj = getattr(obj, segment)
-    return obj
+    return getattr(importlib.import_module(module_name), object_name)
 
 
 def show_exception(stream):
@@ -251,17 +81,49 @@ host_and_port = op.attrgetter("hostname", "port")
 
 def _valid_socket(value):
     # NOTE: without dummy scheme, `urlparse` will not pick up netloc cerrectly
-    res = urlparse(f'scheme://{value}')
+    res = urlparse(f"scheme://{value}")
 
     if not all(host_and_port(res)):
         raise ValueError("Not a socket! Should HOST:PORT", value)
 
-    return str(ip_address(res.hostname)), res.port
+    return str(ip_address(res.hostname)), str(res.port)
+
+
+def _validate_opts(opts):
+    if hasattr(opts, 'listen') and (hasattr(opts, 'host') or hasattr(opts, 'port')):
+        raise ValueError("host or port may not be set if listen is set.")
+
+    if hasattr(opts, 'unix_socket') and (hasattr(opts, 'host') or hasattr(opts, 'port')):
+        raise ValueError("unix_socket may not be set if host or port is set")
+
+    if hasattr(opts, 'unix_socket') and hasattr(opts, 'listen'):
+        raise ValueError("unix_socket may not be set if listen is set")
 
 
 @dataclass(frozen=True)
 class DEFAULTS:
+    BACKLOG = 1024
     HOST = "0.0.0.0"
+    IDENT = "waitress"
+    PORT = 8080
+    THREADS = 4
+    UNIX_SOCKET_PERMS = "600"
+    URL_SCHEME = "http"
+    # fmt: off
+    ASYNCORE_LOOP_TIMEOUT   = 1     # second
+    CHANNEL_TIMEOUT         = 120   # seconds
+    CHANNEL_REQUEST_LOOKAHEAD = 0
+    CLEANUP_INTERVAL        = 30    # seconds
+    CONNECTION_LIMIT        = 100
+    INBUF_HIGH_WATERMARK    = 16777216    # 16  MB
+    INBUF_OVERFLOW          = 524288      # 512 KB
+    MAX_REQUEST_BODY_SIZE   = 1073741824  # 1   GB
+    MAX_REQUEST_HEADER_SIZE = 262144      # 256 KB
+    OUTBUF_HIGH_WATERMARK   = 16777216    # 16  MB
+    OUTBUF_OVERFLOW         = 1048576     # 1   MB
+    RECV_BYTES              = 8192        # 8   KB
+    SEND_BYTES              = 18000
+    # fmt: on
 
 
 def run(argv=sys.argv, _serve=serve):
@@ -274,106 +136,218 @@ def run(argv=sys.argv, _serve=serve):
     )
     parser.add_argument(
         "--call",
-        action="store_false",
+        action="store_true",
         help="Call the given object to get the WSGI application.",
     )
     parser.add_argument(
         "--host",
         type=ip_address,
         default=DEFAULTS.HOST,
-        help="""Hostname or IP address on which to listen, default is %(default)s,
-which means "all IP addresses on this host".
+        help="""Hostname or IP address on which to listen.
+Note: may not be used together with `--listen`.
 
-Note: may not be used together with --listen.""",
+Default is %(default)s, which means "all IP addresses on this host".""",
     )
     parser.add_argument(
         "--port",
         type=int,
-        help="""TCP port on which to listen, default is %(default)s.
+        default=DEFAULTS.PORT,
+        help="""TCP port on which to listen.
+Note: may not be used together with `--listen`.
 
-Note: may not be used together with --listen""",
+Default is %(default)s.""",
     )
     parser.add_argument(
         "--listen",
         type=_valid_socket,
+        action='append',
         help="Tell waitress to listen on an ip port combination.",
     )
     parser.add_argument(
-        "-4", "--ipv4", action=BooleanOptionalAction, help="Toggle on/off IPv4 support."
+        "--ipv4", action=BooleanOptionalAction, help="Toggle on/off IPv4 support."
     )
     parser.add_argument(
-        "-6", "--ipv6", action=BooleanOptionalAction, help="Toggle on/off IPv6 support."
+        "--ipv6", action=BooleanOptionalAction, help="Toggle on/off IPv6 support."
     )
     parser.add_argument(
         "--unix-socket",
         type=pathlib.Path,
-        help="""Path of Unix socket. If a socket path is specified, a Unix domain
-socket is made instead of the usual inet domain socket. Not available on Windows.""",
+        help="""Path of Unix socket. If a socket path is specified, a
+Unix domain socket is made instead of the usual inet domain socket.
+
+Not available on Windows.""",
     )
     parser.add_argument(
         "--unix-socket-perms",
         type=lambda v: int(v, base=8),
-        default="600",
-        help="Octal permissions to use for the Unix domain socket, default is %(default)s",
+        default=DEFAULTS.UNIX_SOCKET_PERMS,
+        help="""Octal permissions to use for the Unix domain socket.
+Default is %(default)s.""",
     )
     parser.add_argument(
         "--url-scheme",
-        default="http",
-        help="Default wsgi.url_scheme value, default is %(default)s.",
+        default=DEFAULTS.URL_SCHEME,
+        help="Default `wsgi.url_scheme` value. Default is %(default)r.",
     )
     parser.add_argument(
         "--url-prefix",
-        help="""The `SCRIPT_NAME` WSGI environment value. Setting this to anything
-except the empty string will cause the WSGI `SCRIPT_NAME` value to be
+        help="""The `SCRIPT_NAME` WSGI environment value. Setting this to
+anything except the empty string will cause the WSGI `SCRIPT_NAME` value to be
 the value passed minus any trailing slashes you add, and it will cause
 the `PATH_INFO` of any request which is prefixed with this value to be
 stripped of the prefix.""",
     )
     parser.add_argument(
         "--ident",
-        default="waitress",
-        help="Server identity used in the 'Server' header in responses. Default is %(default)s",
+        default=DEFAULTS.IDENT,
+        help="""Server identity used in the 'Server' header in responses.
+Default is %(default)r.""",
     )
     # Tuning options
-    parser.add_argument("--threads", type=int, default="4")
-    parser.add_argument("--backlog", type=int, default="1024")
-    parser.add_argument("--recv-bytes", type=int)
-    parser.add_argument("--send-bytes", type=int)
-    parser.add_argument("--outbuf-overflow", type=int)
-    parser.add_argument("--outbuf-high-watermark", type=int)
-    parser.add_argument("--inbuf-overflow", type=int)
-    parser.add_argument("--connection-limit", type=int)
-    parser.add_argument("--cleanup-interval", type=int)
-    parser.add_argument("--channel-timeout", type=int)
-    parser.add_argument("--log-socket-errors", action=BooleanOptionalAction)
-    parser.add_argument("--max-request-header-size", type=int)
-    parser.add_argument("--max-request-body-size", type=int)
-    parser.add_argument("--expose-tracebacks", action=BooleanOptionalAction)
-    parser.add_argument("--asyncore-loop-timeout", type=int)
-    parser.add_argument("--asyncore-use-pool", action="store_true")
-    parser.add_argument("--channel-request-lookahead", type=int)
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=DEFAULTS.THREADS,
+        help="""Number of threads used to process application logic.
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--backlog",
+        type=int,
+        default=DEFAULTS.BACKLOG,
+        help="""Connection backlog for the server. Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--recv-bytes",
+        type=int,
+        default=DEFAULTS.RECV_BYTES,
+        help="""Number of bytes to request when calling `socket.recv()`.
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--send-bytes",
+        type=int,
+        default=DEFAULTS.SEND_BYTES,
+        help="""Number of bytes to send to `socket.send()`.
+Note: multiples of 9000 should avoid partly-filled TCP packets.
 
-    args = parser.parse_args()
-    print(args)
+Default is %(default)s bytes.""",
 
-    sys.exit(0)
+    )
+    parser.add_argument(
+        "--outbuf-overflow",
+        type=int,
+        default=DEFAULTS.OUTBUF_OVERFLOW,
+        help="""A temporary file should be created if the pending output is larger
+than this.
+
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--outbuf-high-watermark",
+        type=int,
+        default=DEFAULTS.OUTBUF_HIGH_WATERMARK,
+        help="""The `app_iter` will pause when pending output is larger than
+this value and will resume once enough data is written to the socket to fall
+below this threshold.
+
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--inbuf-overflow",
+        type=int,
+        default=DEFAULTS.INBUF_OVERFLOW,
+        help="""A temporary file should be created if the pending input is larger
+than this.
+
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--connection-limit",
+        type=int,
+        default=DEFAULTS.CONNECTION_LIMIT,
+        help="""Stop creating new channels if too many are already active.
+
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--cleanup-interval",
+        type=int,
+        default=DEFAULTS.CLEANUP_INTERVAL,
+        help="""Minimum seconds between cleaning up inactive channels.
+See `--channel-timeout` option.
+
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--channel-timeout",
+        type=int,
+        default=DEFAULTS.CHANNEL_TIMEOUT,
+        help="""Maximum number of seconds to leave inactive connections open.
+'Inactive' is defined as 'has received no data from the client and has sent
+no data to the client'.
+
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--max-request-header-size",
+        type=int,
+        default=DEFAULTS.MAX_REQUEST_HEADER_SIZE,
+        help="""Maximum size of all request headers combined.
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--max-request-body-size",
+        type=int,
+        default=DEFAULTS.MAX_REQUEST_BODY_SIZE,
+        help="""Maximum size of request body.
+Default is %(default)s bytes.""",
+    )
+    parser.add_argument(
+        "--asyncore-loop-timeout",
+        type=int,
+        default=DEFAULTS.ASYNCORE_LOOP_TIMEOUT,
+        help="""The timeout value in seconds passed to `asyncore.loop()`.
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--asyncore-use-poll",
+        action="store_true",
+        help="""The `use_poll` argument passed to `asyncore.loop()`. Helps overcome
+open file descriptors limit.
+
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--channel-request-lookahead",
+        type=int,
+        default=DEFAULTS.CHANNEL_REQUEST_LOOKAHEAD,
+        help="""Allows channels to stay readable and buffer more requests up to
+the given maximum even if a request is already being processed. This allows
+detecting if a client closed the connection while its request is being processed.
+
+Default is %(default)s.""",
+    )
+    parser.add_argument(
+        "--log-socket-errors",
+        action=BooleanOptionalAction,
+        help="""Toggle whether premature client disconnect tracebacks ought to be
+logged.
+
+Default is 'no'.""",
+    )
+    parser.add_argument(
+        "--expose-tracebacks",
+        action=BooleanOptionalAction,
+        help="""Toggle whether to expose tracebacks of unhandled exceptions to the
+client.
+
+Default is 'no'.""",
+    )
+
+    args = parser.parse_args(argv)
 
     """Command line runner."""
-    name = os.path.basename(argv[0])
-
-    try:
-        kw, args = Adjustments.parse_args(argv[1:])
-    except getopt.GetoptError as exc:
-        show_help(sys.stderr, name, str(exc))
-        return 1
-
-    if kw["help"]:
-        show_help(sys.stdout, name)
-        return 0
-
-    if len(args) != 1:
-        show_help(sys.stderr, name, "Specify one application only")
-        return 1
 
     # set a default level for the logger only if it hasn't been set explicitly
     # note that this level does not override any parent logger levels,
@@ -382,9 +356,11 @@ stripped of the prefix.""",
         logger.setLevel(logging.INFO)
 
     try:
-        module, obj_name = match(args[0])
+        module, obj_name = match(args.app)
+        del args.app
     except ValueError as exc:
-        show_help(sys.stderr, name, str(exc))
+        print(exc, file=sys.stderr)
+        parser.print_help(file=sys.stderr)
         show_exception(sys.stderr)
         return 1
 
@@ -395,18 +371,22 @@ stripped of the prefix.""",
     try:
         app = resolve(module, obj_name)
     except ImportError:
-        show_help(sys.stderr, name, f"Bad module '{module}'")
+        print(f"Bad module {module!r}", file=sys.stderr)
+        parser.print_help(file=sys.stderr)
         show_exception(sys.stderr)
         return 1
     except AttributeError:
-        show_help(sys.stderr, name, f"Bad object name '{obj_name}'")
+        print(f"Bad object name {obj_name!r}", file=sys.stderr)
+        parser.print_help(file=sys.stderr)
         show_exception(sys.stderr)
         return 1
-    if kw["call"]:
+    if args.call:
         app = app()
+    del args.call
 
-    # These arguments are specific to the runner, not waitress itself.
-    del kw["call"], kw["help"]
+    from pprint import pprint as pp; pp(vars(args))
+    opts = {k: v for k, v in vars(args).items() if v is not None}
+    _validate_opts(opts)
+    _serve(app, opts)
 
-    _serve(app, **kw)
     return 0

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -332,7 +332,7 @@ Default is 'no'.""",
 
     # Get the WSGI function.
     try:
-        app = pkgutil.resolve_name(args[0])
+        app = pkgutil.resolve_name(args.app)
     except ImportError:
         print(f"Bad module {module!r}", file=sys.stderr)
         parser.print_help(file=sys.stderr)

--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -30,23 +30,19 @@ from .proxy_headers import proxy_headers_middleware
 
 def create_server(
     application,
+    opts, # dict
     map=None,
     _start=True,  # test shim
     _sock=None,  # test shim
     _dispatcher=None,  # test shim
     **kw  # adjustments
 ):
-    """
-    if __name__ == '__main__':
-        server = create_server(app)
-        server.run()
-    """
     if application is None:
         raise ValueError(
             'The "app" passed to ``create_server`` was ``None``.  You forgot '
             "to return a WSGI app within your application."
         )
-    adj = Adjustments(**kw)
+    adj = Adjustments(opts, **kw)
 
     if map is None:  # pragma: nocover
         map = {}
@@ -196,7 +192,7 @@ class BaseWSGIServer(wasyncore.dispatcher):
         **kw
     ):
         if adj is None:
-            adj = Adjustments(**kw)
+            adj = Adjustments({}, **kw)
 
         if adj.trusted_proxy or adj.clear_untrusted_proxy_headers:
             # wrap the application to deal with proxy headers

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -104,7 +104,7 @@ class TestAdjustments(unittest.TestCase):
     def _makeOne(self, **kw):
         from waitress.adjustments import Adjustments
 
-        return Adjustments(**kw)
+        return Adjustments({}, **kw)
 
     def test_goodvars(self):
         inst = self._makeOne(
@@ -472,7 +472,7 @@ if hasattr(socket, "AF_UNIX"):
         def _makeOne(self, **kw):
             from waitress.adjustments import Adjustments
 
-            return Adjustments(**kw)
+            return Adjustments({}, **kw)
 
         def test_dont_mix_internet_and_unix_sockets(self):
             sockets = [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,7 @@ class Test_serve(unittest.TestCase):
     def _callFUT(self, app, **kw):
         from waitress import serve
 
-        return serve(app, **kw)
+        return serve(app, {}, **kw)
 
     def test_it(self):
         server = DummyServerFactory()
@@ -34,7 +34,7 @@ class Test_serve_paste(unittest.TestCase):
 class DummyServerFactory:
     ran = False
 
-    def __call__(self, app, **kw):
+    def __call__(self, app, opts, **kw):
         self.adj = DummyAdj(kw)
         self.app = app
         self.kw = kw

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,7 +35,7 @@ from waitress.utilities import (
 
 class TestHTTPRequestParser(unittest.TestCase):
     def setUp(self):
-        my_adj = Adjustments()
+        my_adj = Adjustments({})
         self.parser = HTTPRequestParser(my_adj)
 
     def test_get_body_stream_None(self):
@@ -582,7 +582,7 @@ class Test_crack_first_line(unittest.TestCase):
 
 class TestHTTPRequestParserIntegration(unittest.TestCase):
     def setUp(self):
-        my_adj = Adjustments()
+        my_adj = Adjustments({})
         self.parser = HTTPRequestParser(my_adj)
 
     def feed(self, data):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,8 +11,8 @@ from waitress import runner
 
 
 def test_valid_socket():
-    assert runner._valid_socket('0.0.0.0:42') == ('0.0.0.0', 42)
-    assert runner._valid_socket('[2001:db8::1]:42') == ('2001:db8::1', 42)
+    assert runner._valid_socket('0.0.0.0:42') == ('0.0.0.0', '42')
+    assert runner._valid_socket('[2001:db8::1]:42') == ('2001:db8::1', '42')
 
 
 class Test_match(unittest.TestCase):
@@ -76,25 +76,25 @@ class Test_run(unittest.TestCase):
         captured.close()
 
     def test_bad(self):
-        self.match_output(["--bad-opt"], 1, "^Error: option --bad-opt not recognized")
+        self.match_output(["--app=foo:bar", "--bad-opt"], 2, "error: unrecognized arguments: waitress-serve --bad-opt")
 
     def test_help(self):
-        self.match_output(["--help"], 0, "^Usage:\n\n    waitress-serve")
+        self.match_output(["--help"], 0, "^usage: waitress-serve")
 
     def test_no_app(self):
-        self.match_output([], 1, "^Error: Specify one application only")
+        self.match_output([], 2, "error: the following arguments are required: --app")
 
     def test_multiple_apps_app(self):
-        self.match_output(["a:a", "b:b"], 1, "^Error: Specify one application only")
+        self.match_output(["--app", "a:a", "--app", "b:b"], 1, "^Error: Specify one application only")
 
     def test_bad_apps_app(self):
-        self.match_output(["a"], 1, "^Error: Malformed application 'a'")
+        self.match_output(["--app", "a"], 1, "^Error: Malformed application 'a'")
 
     def test_bad_app_module(self):
-        self.match_output(["nonexistent:a"], 1, "^Error: Bad module 'nonexistent'")
+        self.match_output(["--app", "nonexistent:a"], 1, "^Error: Bad module 'nonexistent'")
 
         self.match_output(
-            ["nonexistent:a"],
+            ["--app", "nonexistent:a"],
             1,
             (
                 r"There was an exception \((ImportError|ModuleNotFoundError)\) "
@@ -113,7 +113,7 @@ class Test_run(unittest.TestCase):
             os.chdir(os.path.dirname(__file__))
             argv = [
                 "waitress-serve",
-                "fixtureapps.runner:app",
+                "--app", "fixtureapps.runner:app",
             ]
             self.assertEqual(runner.run(argv=argv, _serve=null_serve), 0)
         finally:
@@ -135,7 +135,7 @@ class Test_run(unittest.TestCase):
         argv = [
             "waitress-serve",
             "--port=80",
-            "tests.fixtureapps.runner:app",
+            "--app=tests.fixtureapps.runner:app",
         ]
         self.assertEqual(runner.run(argv=argv, _serve=check_server), 0)
 
@@ -150,7 +150,7 @@ class Test_run(unittest.TestCase):
             "waitress-serve",
             "--port=80",
             "--call",
-            "tests.fixtureapps.runner:returns_app",
+            "--app=tests.fixtureapps.runner:returns_app",
         ]
         self.assertEqual(runner.run(argv=argv, _serve=check_server), 0)
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,6 +10,11 @@ else:  # pragma: no cover
 from waitress import runner
 
 
+def test_valid_socket():
+    assert runner._valid_socket('0.0.0.0:42') == ('0.0.0.0', 42)
+    assert runner._valid_socket('[2001:db8::1]:42') == ('2001:db8::1', 42)
+
+
 class Test_match(unittest.TestCase):
     def test_empty(self):
         self.assertRaisesRegex(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@ class TestWSGIServer(unittest.TestCase):
 
         self.inst = create_server(
             application,
+            {},
             host=host,
             port=port,
             map=map,
@@ -57,6 +58,7 @@ class TestWSGIServer(unittest.TestCase):
 
         self.inst = create_server(
             app,
+            {},
             listen=listen,
             map=map,
             _dispatcher=task_dispatcher,
@@ -82,6 +84,7 @@ class TestWSGIServer(unittest.TestCase):
             _sockets = sockets
         self.inst = create_server(
             application,
+            {},
             map=map,
             _dispatcher=_dispatcher,
             _start=_start,
@@ -322,6 +325,7 @@ if hasattr(socket, "AF_UNIX"):
 
             self.inst = create_server(
                 dummy_app,
+                {},
                 map={},
                 _start=_start,
                 _sock=_sock,
@@ -348,6 +352,7 @@ if hasattr(socket, "AF_UNIX"):
                 _sockets = sockets
             self.inst = create_server(
                 application,
+                {},
                 map=map,
                 _dispatcher=_dispatcher,
                 _start=_start,


### PR DESCRIPTION
Closes #439.

At this time, it contains only re-write of parsing to stdlib's `argparse`. You can test overall "look & feel" just by running `waitress-serve` with `--help`, and other arguments.

Not all parsing is done yet, but I think the whole `Adjustments` is not needed anymore - even `argparse` is powerful enough to handle common types, but "not so common" also - take a look at `-4/-6` args (those was not there already, but they go in the style of `ip` from `iproute2` - is it good thing at all?)

Another observation is that there is "boolean" options, but not all of them passed/works the same: some use `--arg/--no-arg` notation, but some works just as "if it passed then it's true" (but there also "reverse", notable example is `--call`). Should they all be reworked to `--[no]-arg` form, or something other?
