### PR TITLE
Use modern assertion methods where appropriate

### DIFF
--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -14,35 +14,35 @@ class Test_asbool(unittest.TestCase):
 
     def test_s_is_None(self):
         result = self._callFUT(None)
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test_s_is_True(self):
         result = self._callFUT(True)
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     def test_s_is_False(self):
         result = self._callFUT(False)
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test_s_is_true(self):
         result = self._callFUT("True")
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     def test_s_is_false(self):
         result = self._callFUT("False")
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test_s_is_yes(self):
         result = self._callFUT("yes")
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     def test_s_is_on(self):
         result = self._callFUT("on")
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     def test_s_is_1(self):
         result = self._callFUT(1)
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
 
 class Test_as_socket_list(unittest.TestCase):
@@ -57,7 +57,7 @@ class Test_as_socket_list(unittest.TestCase):
         if hasattr(socket, "AF_UNIX"):
             sockets.append(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM))
         new_sockets = as_socket_list(sockets)
-        self.assertEqual(sockets, new_sockets)
+        self.assertListEqual(sockets, new_sockets)
 
         for sock in sockets:
             sock.close()
@@ -71,7 +71,7 @@ class Test_as_socket_list(unittest.TestCase):
             {"something": "else"},
         ]
         new_sockets = as_socket_list(sockets)
-        self.assertEqual(new_sockets, [sockets[0], sockets[1]])
+        self.assertListEqual(new_sockets, [sockets[0], sockets[1]])
 
         for sock in [sock for sock in sockets if isinstance(sock, socket.socket)]:
             sock.close()
@@ -141,9 +141,9 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.port, 8080)
         self.assertEqual(inst.threads, 5)
         self.assertEqual(inst.trusted_proxy, "192.168.1.1")
-        self.assertEqual(inst.trusted_proxy_headers, {"forwarded"})
+        self.assertSetEqual(inst.trusted_proxy_headers, {"forwarded"})
         self.assertEqual(inst.trusted_proxy_count, 2)
-        self.assertEqual(inst.log_untrusted_proxy_headers, True)
+        self.assertTrue(inst.log_untrusted_proxy_headers)
         self.assertEqual(inst.url_scheme, "https")
         self.assertEqual(inst.backlog, 20)
         self.assertEqual(inst.recv_bytes, 200)
@@ -153,17 +153,17 @@ class TestAdjustments(unittest.TestCase):
         self.assertEqual(inst.connection_limit, 1000)
         self.assertEqual(inst.cleanup_interval, 1100)
         self.assertEqual(inst.channel_timeout, 1200)
-        self.assertEqual(inst.log_socket_errors, True)
+        self.assertTrue(inst.log_socket_errors)
         self.assertEqual(inst.max_request_header_size, 1300)
         self.assertEqual(inst.max_request_body_size, 1400)
-        self.assertEqual(inst.expose_tracebacks, True)
+        self.assertTrue(inst.expose_tracebacks)
         self.assertEqual(inst.asyncore_loop_timeout, 5)
-        self.assertEqual(inst.asyncore_use_poll, True)
+        self.assertTrue(inst.asyncore_use_poll)
         self.assertEqual(inst.ident, "abc")
         self.assertEqual(inst.unix_socket_perms, 0o777)
         self.assertEqual(inst.url_prefix, "/foo")
-        self.assertEqual(inst.ipv4, True)
-        self.assertEqual(inst.ipv6, False)
+        self.assertTrue(inst.ipv4)
+        self.assertFalse(inst.ipv6)
 
         bind_pairs = [
             sockaddr[:2]
@@ -173,35 +173,35 @@ class TestAdjustments(unittest.TestCase):
 
         # On Travis, somehow we start listening to two sockets when resolving
         # localhost...
-        self.assertEqual(("127.0.0.1", 8080), bind_pairs[0])
+        self.assertTupleEqual(("127.0.0.1", 8080), bind_pairs[0])
 
     def test_goodvar_listen(self):
         inst = self._makeOne(listen="127.0.0.1")
 
         bind_pairs = [(host, port) for (_, _, _, (host, port)) in inst.listen]
 
-        self.assertEqual(bind_pairs, [("127.0.0.1", 8080)])
+        self.assertListEqual(bind_pairs, [("127.0.0.1", 8080)])
 
     def test_default_listen(self):
         inst = self._makeOne()
 
         bind_pairs = [(host, port) for (_, _, _, (host, port)) in inst.listen]
 
-        self.assertEqual(bind_pairs, [("0.0.0.0", 8080)])
+        self.assertListEqual(bind_pairs, [("0.0.0.0", 8080)])
 
     def test_multiple_listen(self):
         inst = self._makeOne(listen="127.0.0.1:9090 127.0.0.1:8080")
 
         bind_pairs = [sockaddr[:2] for (_, _, _, sockaddr) in inst.listen]
 
-        self.assertEqual(bind_pairs, [("127.0.0.1", 9090), ("127.0.0.1", 8080)])
+        self.assertListEqual(bind_pairs, [("127.0.0.1", 9090), ("127.0.0.1", 8080)])
 
     def test_wildcard_listen(self):
         inst = self._makeOne(listen="*:8080")
 
         bind_pairs = [sockaddr[:2] for (_, _, _, sockaddr) in inst.listen]
 
-        self.assertTrue(len(bind_pairs) >= 1)
+        self.assertGreaterEqual(len(bind_pairs), 1)
 
     def test_ipv6_no_port(self):  # pragma: nocover
         if not self._hasIPv6():
@@ -211,7 +211,7 @@ class TestAdjustments(unittest.TestCase):
 
         bind_pairs = [sockaddr[:2] for (_, _, _, sockaddr) in inst.listen]
 
-        self.assertEqual(bind_pairs, [("::1", 8080)])
+        self.assertListEqual(bind_pairs, [("::1", 8080)])
 
     def test_bad_port(self):
         self.assertRaises(ValueError, self._makeOne, listen="127.0.0.1:test")
@@ -231,7 +231,7 @@ class TestAdjustments(unittest.TestCase):
 
         bind_pairs = [sockaddr[:2] for (_, _, _, sockaddr) in inst.listen]
 
-        self.assertEqual(bind_pairs, [("127.0.0.1", 80), ("0.0.0.0", 443)])
+        self.assertListEqual(bind_pairs, [("127.0.0.1", 80), ("0.0.0.0", 443)])
 
     def test_dont_mix_host_port_listen(self):
         self.assertRaises(
@@ -248,7 +248,7 @@ class TestAdjustments(unittest.TestCase):
             socket.socket(socket.AF_INET, socket.SOCK_STREAM),
         ]
         inst = self._makeOne(sockets=sockets)
-        self.assertEqual(inst.sockets, sockets)
+        self.assertListEqual(inst.sockets, sockets)
         sockets[0].close()
         sockets[1].close()
 
@@ -330,7 +330,7 @@ class TestAdjustments(unittest.TestCase):
             trusted_proxy="localhost",
             trusted_proxy_headers="x-forwarded-for x-forwarded-by",
         )
-        self.assertEqual(
+        self.assertSetEqual(
             inst.trusted_proxy_headers, {"x-forwarded-for", "x-forwarded-by"}
         )
 
@@ -339,7 +339,7 @@ class TestAdjustments(unittest.TestCase):
             trusted_proxy="localhost",
             trusted_proxy_headers="x-forwarded-for\nx-forwarded-by\nx-forwarded-host",
         )
-        self.assertEqual(
+        self.assertSetEqual(
             inst.trusted_proxy_headers,
             {"x-forwarded-for", "x-forwarded-by", "x-forwarded-host"},
         )
@@ -377,10 +377,10 @@ class TestAdjustments(unittest.TestCase):
 
     def test_server_header_removable(self):
         inst = self._makeOne(ident=None)
-        self.assertEqual(inst.ident, None)
+        self.assertIsNone(inst.ident)
 
         inst = self._makeOne(ident="")
-        self.assertEqual(inst.ident, None)
+        self.assertIsNone(inst.ident)
 
         inst = self._makeOne(ident="specific_header")
         self.assertEqual(inst.ident, "specific_header")

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -72,7 +72,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.requests = True
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertEqual(inst.last_activity, 0)
 
     def test_handle_write_no_request_with_outbuf(self):
@@ -82,7 +82,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.total_outbufs_len = len(inst.outbufs[0])
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertNotEqual(inst.last_activity, 0)
         self.assertEqual(sock.sent, b"abc")
 
@@ -97,7 +97,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.last_activity = 0
         inst.logger = DummyLogger()
         result = inst.handle_write()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertEqual(inst.last_activity, 0)
         self.assertEqual(sock.sent, b"")
         self.assertEqual(len(inst.logger.exceptions), 1)
@@ -112,7 +112,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.last_activity = 0
         inst.logger = DummyLogger()
         result = inst.handle_write()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertEqual(inst.last_activity, 0)
         self.assertEqual(sock.sent, b"")
         self.assertEqual(len(inst.logger.exceptions), 1)
@@ -126,9 +126,9 @@ class TestHTTPChannel(unittest.TestCase):
         inst.will_close = True
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
-        self.assertEqual(inst.connected, False)
-        self.assertEqual(sock.closed, True)
+        self.assertIsNone(result)
+        self.assertFalse(inst.connected)
+        self.assertTrue(sock.closed)
         self.assertEqual(inst.last_activity, 0)
         self.assertTrue(outbuf.closed)
 
@@ -141,8 +141,8 @@ class TestHTTPChannel(unittest.TestCase):
         inst.will_close = False
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
-        self.assertEqual(inst.will_close, False)
+        self.assertIsNone(result)
+        self.assertFalse(inst.will_close)
         self.assertTrue(inst.outbuf_lock.acquired)
         self.assertEqual(sock.sent, b"abc")
 
@@ -155,9 +155,9 @@ class TestHTTPChannel(unittest.TestCase):
         inst.close_when_flushed = True
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
-        self.assertEqual(inst.will_close, True)
-        self.assertEqual(inst.close_when_flushed, False)
+        self.assertIsNone(result)
+        self.assertTrue(inst.will_close)
+        self.assertFalse(inst.close_when_flushed)
         self.assertEqual(sock.sent, b"abc")
         self.assertTrue(outbuf.closed)
 
@@ -165,18 +165,18 @@ class TestHTTPChannel(unittest.TestCase):
         inst, sock, map = self._makeOneWithMap()
         inst.requests = []
         inst.will_close = False
-        self.assertEqual(inst.readable(), True)
+        self.assertTrue(inst.readable())
 
     def test_readable_no_requests_will_close(self):
         inst, sock, map = self._makeOneWithMap()
         inst.requests = []
         inst.will_close = True
-        self.assertEqual(inst.readable(), False)
+        self.assertFalse(inst.readable())
 
     def test_readable_with_requests(self):
         inst, sock, map = self._makeOneWithMap()
         inst.requests = [True]
-        self.assertEqual(inst.readable(), False)
+        self.assertFalse(inst.readable())
 
     def test_handle_read_no_error(self):
         inst, sock, map = self._makeOneWithMap()
@@ -186,9 +186,9 @@ class TestHTTPChannel(unittest.TestCase):
         L = []
         inst.received = lambda x: L.append(x)
         result = inst.handle_read()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertNotEqual(inst.last_activity, 0)
-        self.assertEqual(L, [b"abc"])
+        self.assertListEqual(L, [b"abc"])
 
     def test_handle_read_error(self):
         inst, sock, map = self._makeOneWithMap()
@@ -201,7 +201,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.last_activity = 0
         inst.logger = DummyLogger()
         result = inst.handle_read()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         self.assertEqual(inst.last_activity, 0)
         self.assertEqual(len(inst.logger.exceptions), 1)
 
@@ -363,8 +363,8 @@ class TestHTTPChannel(unittest.TestCase):
         inst.will_close = False
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
-        self.assertEqual(inst.will_close, False)
+        self.assertIsNone(result)
+        self.assertFalse(inst.will_close)
         self.assertTrue(inst.outbuf_lock.acquired)
         self.assertTrue(inst.outbuf_lock.notified)
         self.assertEqual(sock.sent, b"abc")
@@ -380,8 +380,8 @@ class TestHTTPChannel(unittest.TestCase):
         inst.will_close = False
         inst.last_activity = 0
         result = inst.handle_write()
-        self.assertEqual(result, None)
-        self.assertEqual(inst.will_close, False)
+        self.assertIsNone(result)
+        self.assertFalse(inst.will_close)
         self.assertTrue(inst.outbuf_lock.acquired)
         self.assertFalse(inst.outbuf_lock.notified)
         self.assertEqual(sock.sent, b"")
@@ -389,14 +389,14 @@ class TestHTTPChannel(unittest.TestCase):
     def test__flush_some_empty_outbuf(self):
         inst, sock, map = self._makeOneWithMap()
         result = inst._flush_some()
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test__flush_some_full_outbuf_socket_returns_nonzero(self):
         inst, sock, map = self._makeOneWithMap()
         inst.outbufs[0].append(b"abc")
         inst.total_outbufs_len = sum(len(x) for x in inst.outbufs)
         result = inst._flush_some()
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     def test__flush_some_full_outbuf_socket_returns_zero(self):
         inst, sock, map = self._makeOneWithMap()
@@ -404,7 +404,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.outbufs[0].append(b"abc")
         inst.total_outbufs_len = sum(len(x) for x in inst.outbufs)
         result = inst._flush_some()
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test_flush_some_multiple_buffers_first_empty(self):
         inst, sock, map = self._makeOneWithMap()
@@ -413,9 +413,9 @@ class TestHTTPChannel(unittest.TestCase):
         inst.outbufs.append(buffer)
         inst.total_outbufs_len = sum(len(x) for x in inst.outbufs)
         result = inst._flush_some()
-        self.assertEqual(result, True)
+        self.assertTrue(result)
         self.assertEqual(buffer.skipped, 3)
-        self.assertEqual(inst.outbufs, [buffer])
+        self.assertListEqual(inst.outbufs, [buffer])
 
     def test_flush_some_multiple_buffers_close_raises(self):
         inst, sock, map = self._makeOneWithMap()
@@ -430,9 +430,9 @@ class TestHTTPChannel(unittest.TestCase):
 
         inst.outbufs[0].close = doraise
         result = inst._flush_some()
-        self.assertEqual(result, True)
+        self.assertTrue(result)
         self.assertEqual(buffer.skipped, 3)
-        self.assertEqual(inst.outbufs, [buffer])
+        self.assertListEqual(inst.outbufs, [buffer])
         self.assertEqual(len(inst.logger.exceptions), 1)
 
     def test__flush_some_outbuf_len_gt_sys_maxint(self):
@@ -457,13 +457,13 @@ class TestHTTPChannel(unittest.TestCase):
         result = inst._flush_some()
         # we are testing that _flush_some doesn't raise an OverflowError
         # when one of its outbufs has a __len__ that returns gt sys.maxint
-        self.assertEqual(result, False)
+        self.assertFalse(result)
 
     def test_handle_close(self):
         inst, sock, map = self._makeOneWithMap()
         inst.handle_close()
-        self.assertEqual(inst.connected, False)
-        self.assertEqual(sock.closed, True)
+        self.assertFalse(inst.connected)
+        self.assertTrue(sock.closed)
 
     def test_handle_close_outbuf_raises_on_close(self):
         inst, sock, map = self._makeOneWithMap()
@@ -474,8 +474,8 @@ class TestHTTPChannel(unittest.TestCase):
         inst.outbufs[0].close = doraise
         inst.logger = DummyLogger()
         inst.handle_close()
-        self.assertEqual(inst.connected, False)
-        self.assertEqual(sock.closed, True)
+        self.assertFalse(inst.connected)
+        self.assertTrue(sock.closed)
         self.assertEqual(len(inst.logger.exceptions), 1)
 
     def test_add_channel(self):
@@ -490,19 +490,19 @@ class TestHTTPChannel(unittest.TestCase):
         fileno = inst._fileno
         inst.server.active_channels[fileno] = True
         inst.del_channel(map)
-        self.assertEqual(map.get(fileno), None)
-        self.assertEqual(inst.server.active_channels.get(fileno), None)
+        self.assertIsNone(map.get(fileno))
+        self.assertIsNone(inst.server.active_channels.get(fileno))
 
     def test_received(self):
         inst, sock, map = self._makeOneWithMap()
         inst.server = DummyServer()
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
-        self.assertEqual(inst.server.tasks, [inst])
+        self.assertListEqual(inst.server.tasks, [inst])
         self.assertTrue(inst.requests)
 
     def test_received_no_chunk(self):
         inst, sock, map = self._makeOneWithMap()
-        self.assertEqual(inst.received(b""), False)
+        self.assertFalse(inst.received(b""))
 
     def test_received_preq_not_completed(self):
         inst, sock, map = self._makeOneWithMap()
@@ -512,8 +512,8 @@ class TestHTTPChannel(unittest.TestCase):
         preq.completed = False
         preq.empty = True
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
-        self.assertEqual(inst.requests, [])
-        self.assertEqual(inst.server.tasks, [])
+        self.assertListEqual(inst.requests, [])
+        self.assertListEqual(inst.server.tasks, [])
 
     def test_received_preq_completed_empty(self):
         inst, sock, map = self._makeOneWithMap()
@@ -523,8 +523,8 @@ class TestHTTPChannel(unittest.TestCase):
         preq.completed = True
         preq.empty = True
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
-        self.assertEqual(inst.request, None)
-        self.assertEqual(inst.server.tasks, [])
+        self.assertIsNone(inst.request)
+        self.assertListEqual(inst.server.tasks, [])
 
     def test_received_preq_error(self):
         inst, sock, map = self._makeOneWithMap()
@@ -534,7 +534,7 @@ class TestHTTPChannel(unittest.TestCase):
         preq.completed = True
         preq.error = True
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
-        self.assertEqual(inst.request, None)
+        self.assertIsNone(inst.request)
         self.assertEqual(len(inst.server.tasks), 1)
         self.assertTrue(inst.requests)
 
@@ -547,8 +547,8 @@ class TestHTTPChannel(unittest.TestCase):
         preq.empty = True
         preq.connection_close = True
         inst.received(b"GET / HTTP/1.1\r\n\r\n" + b"a" * 50000)
-        self.assertEqual(inst.request, None)
-        self.assertEqual(inst.server.tasks, [])
+        self.assertIsNone(inst.request)
+        self.assertListEqual(inst.server.tasks, [])
 
     def test_received_headers_finished_expect_continue_false(self):
         inst, sock, map = self._makeOneWithMap()
@@ -562,7 +562,7 @@ class TestHTTPChannel(unittest.TestCase):
         preq.retval = 1
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
         self.assertEqual(inst.request, preq)
-        self.assertEqual(inst.server.tasks, [])
+        self.assertListEqual(inst.server.tasks, [])
         self.assertEqual(inst.outbufs[0].get(100), b"")
 
     def test_received_headers_finished_expect_continue_true(self):
@@ -576,10 +576,10 @@ class TestHTTPChannel(unittest.TestCase):
         preq.empty = False
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
         self.assertEqual(inst.request, preq)
-        self.assertEqual(inst.server.tasks, [])
+        self.assertListEqual(inst.server.tasks, [])
         self.assertEqual(sock.sent, b"HTTP/1.1 100 Continue\r\n\r\n")
-        self.assertEqual(inst.sent_continue, True)
-        self.assertEqual(preq.completed, False)
+        self.assertTrue(inst.sent_continue)
+        self.assertFalse(preq.completed)
 
     def test_received_headers_finished_expect_continue_true_sent_true(self):
         inst, sock, map = self._makeOneWithMap()
@@ -593,10 +593,10 @@ class TestHTTPChannel(unittest.TestCase):
         inst.sent_continue = True
         inst.received(b"GET / HTTP/1.1\r\n\r\n")
         self.assertEqual(inst.request, preq)
-        self.assertEqual(inst.server.tasks, [])
+        self.assertListEqual(inst.server.tasks, [])
         self.assertEqual(sock.sent, b"")
-        self.assertEqual(inst.sent_continue, True)
-        self.assertEqual(preq.completed, False)
+        self.assertTrue(inst.sent_continue)
+        self.assertFalse(preq.completed)
 
     def test_service_with_one_request(self):
         inst, sock, map = self._makeOneWithMap()
@@ -604,7 +604,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.task_class = DummyTaskClass()
         inst.requests = [request]
         inst.service()
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertTrue(request.serviced)
         self.assertTrue(request.closed)
 
@@ -615,7 +615,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.error_task_class = DummyTaskClass()
         inst.requests = [request]
         inst.service()
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertTrue(request.serviced)
         self.assertTrue(request.closed)
 
@@ -627,7 +627,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.requests = [request1, request2]
         inst.service()
         inst.service()
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertTrue(request1.serviced)
         self.assertTrue(request2.serviced)
         self.assertTrue(request1.closed)
@@ -645,12 +645,12 @@ class TestHTTPChannel(unittest.TestCase):
         inst.logger = DummyLogger()
         inst.service()
         self.assertTrue(request.serviced)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.exceptions), 1)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
         self.assertFalse(inst.will_close)
-        self.assertEqual(inst.error_task_class.serviced, True)
+        self.assertTrue(inst.error_task_class.serviced)
         self.assertTrue(request.closed)
 
     def test_service_with_requests_raises_already_wrote_header(self):
@@ -664,12 +664,12 @@ class TestHTTPChannel(unittest.TestCase):
         inst.logger = DummyLogger()
         inst.service()
         self.assertTrue(request.serviced)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.exceptions), 1)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
         self.assertTrue(inst.close_when_flushed)
-        self.assertEqual(inst.error_task_class.serviced, False)
+        self.assertFalse(inst.error_task_class.serviced)
         self.assertTrue(request.closed)
 
     def test_service_with_requests_raises_didnt_write_header_expose_tbs(self):
@@ -685,11 +685,11 @@ class TestHTTPChannel(unittest.TestCase):
         inst.service()
         self.assertTrue(request.serviced)
         self.assertFalse(inst.will_close)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.exceptions), 1)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
-        self.assertEqual(inst.error_task_class.serviced, True)
+        self.assertTrue(inst.error_task_class.serviced)
         self.assertTrue(request.closed)
 
     def test_service_with_requests_raises_didnt_write_header(self):
@@ -703,7 +703,7 @@ class TestHTTPChannel(unittest.TestCase):
         inst.logger = DummyLogger()
         inst.service()
         self.assertTrue(request.serviced)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.exceptions), 1)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
@@ -723,12 +723,12 @@ class TestHTTPChannel(unittest.TestCase):
         inst.logger = DummyLogger()
         inst.service()
         self.assertTrue(request.serviced)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.infos), 1)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
         self.assertFalse(inst.will_close)
-        self.assertEqual(inst.error_task_class.serviced, False)
+        self.assertFalse(inst.error_task_class.serviced)
         self.assertTrue(request.closed)
 
     def test_service_with_request_error_raises_disconnect(self):
@@ -748,27 +748,27 @@ class TestHTTPChannel(unittest.TestCase):
         inst.service()
         self.assertTrue(request.serviced)
         self.assertTrue(err_request.serviced)
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
         self.assertEqual(len(inst.logger.exceptions), 1)
         self.assertEqual(len(inst.logger.infos), 0)
         self.assertTrue(inst.server.trigger_pulled)
         self.assertTrue(inst.last_activity)
         self.assertFalse(inst.will_close)
-        self.assertEqual(inst.task_class.serviced, True)
-        self.assertEqual(inst.error_task_class.serviced, True)
+        self.assertTrue(inst.task_class.serviced)
+        self.assertTrue(inst.error_task_class.serviced)
         self.assertTrue(request.closed)
 
     def test_cancel_no_requests(self):
         inst, sock, map = self._makeOneWithMap()
         inst.requests = ()
         inst.cancel()
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
 
     def test_cancel_with_requests(self):
         inst, sock, map = self._makeOneWithMap()
         inst.requests = [None]
         inst.cancel()
-        self.assertEqual(inst.requests, [])
+        self.assertListEqual(inst.requests, [])
 
 
 class TestHTTPChannelLookahead(TestHTTPChannel):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -317,7 +317,7 @@ class EchoTests:
             self.assertline(line, "200", "OK", "HTTP/1.1")
             self.assertEqual(echo.body, b"")
             self.assertEqual(echo.content_length, "0")
-            self.assertFalse("transfer-encoding" in headers)
+            self.assertNotIn("transfer-encoding", headers)
 
     def test_chunking_request_with_content(self):
         control_line = b"20\r\n"  # 20 hex = 32 dec
@@ -336,7 +336,7 @@ class EchoTests:
             self.assertline(line, "200", "OK", "HTTP/1.1")
             self.assertEqual(echo.body, expected)
             self.assertEqual(echo.content_length, str(len(expected)))
-            self.assertFalse("transfer-encoding" in headers)
+            self.assertNotIn("transfer-encoding", headers)
 
     def test_broken_chunked_encoding(self):
         control_line = b"20\r\n"  # 20 hex = 32 dec
@@ -421,7 +421,7 @@ class EchoTests:
             self.assertline(line, "400", "Bad Request", "HTTP/1.1")
             cl = int(headers["content-length"])
             self.assertEqual(cl, len(response_body))
-            self.assertTrue(b"Chunk not properly terminated" in response_body)
+            self.assertIn(b"Chunk not properly terminated", response_body)
             self.assertEqual(
                 sorted(headers.keys()),
                 ["connection", "content-length", "content-type", "date", "server"],
@@ -443,7 +443,7 @@ class EchoTests:
         connection = response.getheader("Connection", "")
         # We sent no Connection: Keep-Alive header
         # Connection: close (or no header) is default.
-        self.assertTrue(connection != "Keep-Alive")
+        self.assertNotEqual(connection, "Keep-Alive")
 
     def test_keepalive_http10_explicit(self):
         # If header Connection: Keep-Alive is explicitly sent,
@@ -476,7 +476,7 @@ class EchoTests:
         response = httplib.HTTPResponse(self.sock)
         response.begin()
         self.assertEqual(int(response.status), 200)
-        self.assertTrue(response.getheader("connection") != "close")
+        self.assertNotEqual(response.getheader("connection"), "close")
 
     def test_keepalive_http11_explicit(self):
         # Explicitly set keep-alive
@@ -493,7 +493,7 @@ class EchoTests:
         response = httplib.HTTPResponse(self.sock)
         response.begin()
         self.assertEqual(int(response.status), 200)
-        self.assertTrue(response.getheader("connection") != "close")
+        self.assertNotEqual(response.getheader("connection"), "close")
 
     def test_keepalive_http11_connclose(self):
         # specifying Connection: close explicitly
@@ -706,7 +706,7 @@ class NoContentLengthTests:
         with self.sock.makefile("rb", 0) as fp:
             line, headers, response_body = read_http(fp)
             self.assertline(line, "200", "OK", "HTTP/1.0")
-            self.assertEqual(headers.get("content-length"), None)
+            self.assertIsNone(headers.get("content-length"))
             self.assertEqual(headers.get("connection"), "close")
             self.assertEqual(response_body, body)
             # remote closed connection (despite keepalive header), because
@@ -749,7 +749,7 @@ class NoContentLengthTests:
         with self.sock.makefile("rb", 0) as fp:
             line, headers, response_body = read_http(fp)
             self.assertline(line, "200", "OK", "HTTP/1.0")
-            self.assertEqual(headers.get("content-length"), None)
+            self.assertIsNone(headers.get("content-length"))
             self.assertEqual(headers.get("connection"), "close")
             self.assertEqual(response_body, body)
             # remote closed connection (despite keepalive header), because
@@ -914,7 +914,7 @@ class WriteCallbackTests:
             line = fp.readline()  # status line
             line, headers, response_body = read_http(fp)
             content_length = headers.get("content-length")
-            self.assertEqual(content_length, None)
+            self.assertIsNone(content_length)
             self.assertEqual(response_body, b"abcdefghi")
             # remote closed connection (despite keepalive header)
             self.send_check_error(to_send)
@@ -1332,7 +1332,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377\330\377" in response_body)
+                self.assertIn(b"\377\330\377", response_body)
                 # connection has not been closed
 
     def test_filelike_nocl_http11(self):
@@ -1349,7 +1349,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377\330\377" in response_body)
+                self.assertIn(b"\377\330\377", response_body)
                 # connection has not been closed
 
     def test_filelike_shortcl_http11(self):
@@ -1367,7 +1367,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377" in response_body)
+                self.assertIn(b"\377", response_body)
                 # connection has not been closed
 
     def test_filelike_longcl_http11(self):
@@ -1384,7 +1384,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377\330\377" in response_body)
+                self.assertIn(b"\377\330\377", response_body)
                 # connection has not been closed
 
     def test_notfilelike_http11(self):
@@ -1401,7 +1401,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377\330\377" in response_body)
+                self.assertIn(b"\377\330\377", response_body)
                 # connection has not been closed
 
     def test_notfilelike_iobase_http11(self):
@@ -1418,7 +1418,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377\330\377" in response_body)
+                self.assertIn(b"\377\330\377", response_body)
                 # connection has not been closed
 
     def test_notfilelike_nocl_http11(self):
@@ -1432,7 +1432,7 @@ class FileWrapperTests:
             self.assertline(line, "200", "OK", "HTTP/1.1")
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed (no content-length)
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)
@@ -1452,7 +1452,7 @@ class FileWrapperTests:
                 self.assertEqual(cl, len(response_body))
                 ct = headers["content-type"]
                 self.assertEqual(ct, "image/jpeg")
-                self.assertTrue(b"\377" in response_body)
+                self.assertIn(b"\377", response_body)
                 # connection has not been closed
 
     def test_notfilelike_longcl_http11(self):
@@ -1468,7 +1468,7 @@ class FileWrapperTests:
             self.assertEqual(cl, len(response_body) + 10)
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)
@@ -1486,7 +1486,7 @@ class FileWrapperTests:
             self.assertEqual(cl, len(response_body))
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)
@@ -1504,7 +1504,7 @@ class FileWrapperTests:
             self.assertEqual(cl, len(response_body))
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)
@@ -1522,7 +1522,7 @@ class FileWrapperTests:
             self.assertEqual(cl, len(response_body))
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)
@@ -1538,7 +1538,7 @@ class FileWrapperTests:
             self.assertline(line, "200", "OK", "HTTP/1.0")
             ct = headers["content-type"]
             self.assertEqual(ct, "image/jpeg")
-            self.assertTrue(b"\377\330\377" in response_body)
+            self.assertIn(b"\377\330\377", response_body)
             # connection has been closed (no content-length)
             self.send_check_error(to_send)
             self.assertRaises(ConnectionClosed, read_http, fp)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,8 +12,8 @@ class Test_serve(unittest.TestCase):
         app = object()
         result = self._callFUT(app, _server=server, _quiet=True)
         self.assertEqual(server.app, app)
-        self.assertEqual(result, None)
-        self.assertEqual(server.ran, True)
+        self.assertIsNone(result)
+        self.assertTrue(server.ran)
 
 
 class Test_serve_paste(unittest.TestCase):
@@ -28,7 +28,7 @@ class Test_serve_paste(unittest.TestCase):
         result = self._callFUT(app, _server=server, _quiet=True)
         self.assertEqual(server.app, app)
         self.assertEqual(result, 0)
-        self.assertEqual(server.ran, True)
+        self.assertTrue(server.ran)
 
 
 class DummyServerFactory:

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -14,26 +14,26 @@ class TestFixedStreamReceiver(unittest.TestCase):
         inst = self._makeOne(0, buf)
         result = inst.received("a")
         self.assertEqual(result, 0)
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
 
     def test_received_remain_lte_datalen(self):
         buf = DummyBuffer()
         inst = self._makeOne(1, buf)
         result = inst.received("aa")
         self.assertEqual(result, 1)
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
         self.assertEqual(inst.completed, 1)
         self.assertEqual(inst.remain, 0)
-        self.assertEqual(buf.data, ["a"])
+        self.assertListEqual(buf.data, ["a"])
 
     def test_received_remain_gt_datalen(self):
         buf = DummyBuffer()
         inst = self._makeOne(10, buf)
         result = inst.received("aa")
         self.assertEqual(result, 2)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
         self.assertEqual(inst.remain, 8)
-        self.assertEqual(buf.data, ["aa"])
+        self.assertListEqual(buf.data, ["aa"])
 
     def test_getfile(self):
         buf = DummyBuffer()
@@ -63,7 +63,7 @@ class TestChunkedReceiver(unittest.TestCase):
         inst.completed = True
         result = inst.received(b"a")
         self.assertEqual(result, 0)
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
 
     def test_received_remain_gt_zero(self):
         buf = DummyBuffer()
@@ -72,7 +72,7 @@ class TestChunkedReceiver(unittest.TestCase):
         result = inst.received(b"a")
         self.assertEqual(inst.chunk_remainder, 99)
         self.assertEqual(result, 1)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_control_line_notfinished(self):
         buf = DummyBuffer()
@@ -80,7 +80,7 @@ class TestChunkedReceiver(unittest.TestCase):
         result = inst.received(b"a")
         self.assertEqual(inst.control_line, b"a")
         self.assertEqual(result, 1)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_control_line_finished_garbage_in_input(self):
         buf = DummyBuffer()
@@ -95,18 +95,18 @@ class TestChunkedReceiver(unittest.TestCase):
         result = inst.received(b"a;discard\r\n")
         self.assertEqual(inst.control_line, b"")
         self.assertEqual(inst.chunk_remainder, 10)
-        self.assertEqual(inst.all_chunks_received, False)
+        self.assertFalse(inst.all_chunks_received)
         self.assertEqual(result, 11)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_control_line_finished_all_chunks_received(self):
         buf = DummyBuffer()
         inst = self._makeOne(buf)
         result = inst.received(b"0;discard\r\n")
         self.assertEqual(inst.control_line, b"")
-        self.assertEqual(inst.all_chunks_received, True)
+        self.assertTrue(inst.all_chunks_received)
         self.assertEqual(result, 11)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_trailer_startswith_crlf(self):
         buf = DummyBuffer()
@@ -114,7 +114,7 @@ class TestChunkedReceiver(unittest.TestCase):
         inst.all_chunks_received = True
         result = inst.received(b"\r\n")
         self.assertEqual(result, 2)
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
 
     def test_received_trailer_startswith_lf(self):
         buf = DummyBuffer()
@@ -122,7 +122,7 @@ class TestChunkedReceiver(unittest.TestCase):
         inst.all_chunks_received = True
         result = inst.received(b"\n")
         self.assertEqual(result, 1)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_trailer_not_finished(self):
         buf = DummyBuffer()
@@ -130,7 +130,7 @@ class TestChunkedReceiver(unittest.TestCase):
         inst.all_chunks_received = True
         result = inst.received(b"a")
         self.assertEqual(result, 1)
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
 
     def test_received_trailer_finished(self):
         buf = DummyBuffer()
@@ -139,7 +139,7 @@ class TestChunkedReceiver(unittest.TestCase):
         result = inst.received(b"abc\r\n\r\n")
         self.assertEqual(inst.trailer, b"abc\r\n\r\n")
         self.assertEqual(result, 7)
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
 
     def test_getfile(self):
         buf = DummyBuffer()
@@ -154,7 +154,7 @@ class TestChunkedReceiver(unittest.TestCase):
     def test___len__(self):
         buf = DummyBuffer(["1", "2"])
         inst = self._makeOne(buf)
-        self.assertEqual(inst.__len__(), 2)
+        self.assertEqual(len(inst), 2)
 
     def test_received_chunk_is_properly_terminated(self):
         buf = DummyBuffer()
@@ -162,7 +162,7 @@ class TestChunkedReceiver(unittest.TestCase):
         data = b"4\r\nWiki\r\n"
         result = inst.received(data)
         self.assertEqual(result, len(data))
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
         self.assertEqual(buf.data[0], b"Wiki")
 
     def test_received_chunk_not_properly_terminated(self):
@@ -173,9 +173,9 @@ class TestChunkedReceiver(unittest.TestCase):
         data = b"4\r\nWikibadchunk\r\n"
         result = inst.received(data)
         self.assertEqual(result, len(data))
-        self.assertEqual(inst.completed, False)
+        self.assertFalse(inst.completed)
         self.assertEqual(buf.data[0], b"Wiki")
-        self.assertEqual(inst.error.__class__, BadRequest)
+        self.assertIsInstance(inst.error, BadRequest)
 
     def test_received_multiple_chunks(self):
         from waitress.utilities import BadRequest
@@ -223,9 +223,9 @@ class TestChunkedReceiver(unittest.TestCase):
         result = inst.received(data2)
         self.assertEqual(result, len(data2))
 
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
         self.assertEqual(b"".join(buf.data), b"Wikipedia in\r\n\r\nchunks.")
-        self.assertEqual(inst.error, None)
+        self.assertIsNone(inst.error)
 
 
 class TestChunkedReceiverParametrized:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -163,7 +163,7 @@ class Test_helper(unittest.TestCase):
             try:
                 raise ImportError("My reason")
             except ImportError:
-                self.assertEqual(show_exception(sys.stderr), None)
+                self.assertIsNone(show_exception(sys.stderr))
             self.assertRegex(captured.getvalue(), regex)
         captured.close()
 
@@ -176,7 +176,7 @@ class Test_helper(unittest.TestCase):
             try:
                 raise ImportError
             except ImportError:
-                self.assertEqual(show_exception(sys.stderr), None)
+                self.assertIsNone(show_exception(sys.stderr))
             self.assertRegex(captured.getvalue(), regex)
         captured.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -100,7 +100,7 @@ class TestWSGIServer(unittest.TestCase):
 
     def test_ctor_start_true(self):
         inst = self._makeOneWithMap(_start=True)
-        self.assertEqual(inst.accepting, True)
+        self.assertTrue(inst.accepting)
         self.assertEqual(inst.socket.listened, 1024)
 
     def test_ctor_makes_dispatcher(self):
@@ -111,7 +111,7 @@ class TestWSGIServer(unittest.TestCase):
 
     def test_ctor_start_false(self):
         inst = self._makeOneWithMap(_start=False)
-        self.assertEqual(inst.accepting, False)
+        self.assertFalse(inst.accepting)
 
     def test_get_server_multi(self):
         inst = self._makeOneWithMulti()
@@ -136,13 +136,13 @@ class TestWSGIServer(unittest.TestCase):
         inst.trigger.close()
         inst.trigger = DummyTrigger()
         inst.pull_trigger()
-        self.assertEqual(inst.trigger.pulled, True)
+        self.assertTrue(inst.trigger.pulled)
 
     def test_add_task(self):
         task = DummyTask()
         inst = self._makeOneWithMap()
         inst.add_task(task)
-        self.assertEqual(inst.task_dispatcher.tasks, [task])
+        self.assertListEqual(inst.task_dispatcher.tasks, [task])
         self.assertFalse(task.serviced)
 
     def test_readable_not_accepting(self):
@@ -187,7 +187,7 @@ class TestWSGIServer(unittest.TestCase):
         L = []
         inst.maintenance = lambda t: L.append(t)
         inst.readable()
-        self.assertEqual(L, [])
+        self.assertListEqual(L, [])
         self.assertEqual(inst.next_channel_cleanup, then)
 
     def test_readable_maintenance_true(self):
@@ -205,18 +205,18 @@ class TestWSGIServer(unittest.TestCase):
 
     def test_handle_read(self):
         inst = self._makeOneWithMap()
-        self.assertEqual(inst.handle_read(), None)
+        self.assertIsNone(inst.handle_read())
 
     def test_handle_connect(self):
         inst = self._makeOneWithMap()
-        self.assertEqual(inst.handle_connect(), None)
+        self.assertIsNone(inst.handle_connect())
 
     def test_handle_accept_wouldblock_socket_error(self):
         inst = self._makeOneWithMap()
         ewouldblock = socket.error(errno.EWOULDBLOCK)
         inst.socket = DummySock(toraise=ewouldblock)
         inst.handle_accept()
-        self.assertEqual(inst.socket.accepted, False)
+        self.assertFalse(inst.socket.accepted)
 
     def test_handle_accept_other_socket_error(self):
         inst = self._makeOneWithMap()
@@ -230,7 +230,7 @@ class TestWSGIServer(unittest.TestCase):
         inst.accept = foo
         inst.logger = DummyLogger()
         inst.handle_accept()
-        self.assertEqual(inst.socket.accepted, False)
+        self.assertFalse(inst.socket.accepted)
         self.assertEqual(len(inst.logger.logged), 1)
 
     def test_handle_accept_noerror(self):
@@ -241,9 +241,9 @@ class TestWSGIServer(unittest.TestCase):
         L = []
         inst.channel_class = lambda *arg, **kw: L.append(arg)
         inst.handle_accept()
-        self.assertEqual(inst.socket.accepted, True)
-        self.assertEqual(innersock.opts, [("level", "optname", "value")])
-        self.assertEqual(L, [(inst, innersock, None, inst.adj)])
+        self.assertTrue(inst.socket.accepted)
+        self.assertListEqual(innersock.opts, [("level", "optname", "value")])
+        self.assertListEqual(L, [(inst, innersock, None, inst.adj)])
 
     def test_maintenance(self):
         inst = self._makeOneWithMap()
@@ -256,13 +256,13 @@ class TestWSGIServer(unittest.TestCase):
         zombie.running_tasks = False
         inst.active_channels[100] = zombie
         inst.maintenance(10000)
-        self.assertEqual(zombie.will_close, True)
+        self.assertTrue(zombie.will_close)
 
     def test_backward_compatibility(self):
         from waitress.adjustments import Adjustments
         from waitress.server import TcpWSGIServer, WSGIServer
 
-        self.assertTrue(WSGIServer is TcpWSGIServer)
+        self.assertIs(WSGIServer, TcpWSGIServer)
         self.inst = WSGIServer(None, _start=False, port=1234)
         # Ensure the adjustment was actually applied.
         self.assertNotEqual(Adjustments.port, 1234)
@@ -274,7 +274,7 @@ class TestWSGIServer(unittest.TestCase):
         sockets = [socket.socket(socket.AF_INET, socket.SOCK_STREAM)]
         sockets[0].bind(("127.0.0.1", 0))
         inst = self._makeWithSockets(_start=False, sockets=sockets)
-        self.assertTrue(isinstance(inst, TcpWSGIServer))
+        self.assertIsInstance(inst, TcpWSGIServer)
 
     def test_create_with_multiple_tcp_sockets(self):
         from waitress.server import MultiSocketServer
@@ -286,7 +286,7 @@ class TestWSGIServer(unittest.TestCase):
         sockets[0].bind(("127.0.0.1", 0))
         sockets[1].bind(("127.0.0.1", 0))
         inst = self._makeWithSockets(_start=False, sockets=sockets)
-        self.assertTrue(isinstance(inst, MultiSocketServer))
+        self.assertIsInstance(inst, MultiSocketServer)
         self.assertEqual(len(inst.effective_listen), 2)
 
     def test_create_with_one_socket_should_not_bind_socket(self):
@@ -295,7 +295,7 @@ class TestWSGIServer(unittest.TestCase):
         sockets[0].bind(("127.0.0.1", 80))
         sockets[0].bind_called = False
         inst = self._makeWithSockets(_start=False, sockets=sockets)
-        self.assertEqual(inst.socket.bound, ("127.0.0.1", 80))
+        self.assertTupleEqual(inst.socket.bound, ("127.0.0.1", 80))
         self.assertFalse(inst.socket.bind_called)
 
     def test_create_with_one_socket_handle_accept_noerror(self):
@@ -307,9 +307,9 @@ class TestWSGIServer(unittest.TestCase):
         inst.channel_class = lambda *arg, **kw: L.append(arg)
         inst.adj = DummyAdj
         inst.handle_accept()
-        self.assertEqual(sockets[0].accepted, True)
-        self.assertEqual(innersock.opts, [("level", "optname", "value")])
-        self.assertEqual(L, [(inst, innersock, None, inst.adj)])
+        self.assertTrue(sockets[0].accepted)
+        self.assertListEqual(innersock.opts, [("level", "optname", "value")])
+        self.assertListEqual(L, [(inst, innersock, None, inst.adj)])
 
 
 if hasattr(socket, "AF_UNIX"):
@@ -376,14 +376,14 @@ if hasattr(socket, "AF_UNIX"):
             client = self._makeDummy()
             listen = self._makeDummy(acceptresult=(client, None))
             inst = self._makeOne(_sock=listen)
-            self.assertEqual(inst.accepting, True)
+            self.assertTrue(inst.accepting)
             self.assertEqual(inst.socket.listened, 1024)
             L = []
             inst.channel_class = lambda *arg, **kw: L.append(arg)
             inst.handle_accept()
-            self.assertEqual(inst.socket.accepted, True)
-            self.assertEqual(client.opts, [])
-            self.assertEqual(L, [(inst, client, ("localhost", None), inst.adj)])
+            self.assertTrue(inst.socket.accepted)
+            self.assertListEqual(client.opts, [])
+            self.assertListEqual(L, [(inst, client, ("localhost", None), inst.adj)])
 
         def test_creates_new_sockinfo(self):
             from waitress.server import UnixWSGIServer
@@ -407,12 +407,12 @@ if hasattr(socket, "AF_UNIX"):
                 socket.socket(socket.AF_UNIX, socket.SOCK_STREAM),
             ]
             inst = self._makeWithSockets(sockets=sockets, _start=False)
-            self.assertTrue(isinstance(inst, MultiSocketServer))
+            self.assertIsInstance(inst, MultiSocketServer)
             server = list(
                 filter(lambda s: isinstance(s, BaseWSGIServer), inst.map.values())
             )
-            self.assertTrue(isinstance(server[0], UnixWSGIServer))
-            self.assertTrue(isinstance(server[1], UnixWSGIServer))
+            self.assertIsInstance(server[0], UnixWSGIServer)
+            self.assertIsInstance(server[1], UnixWSGIServer)
 
 
 class DummySock(socket.socket):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -26,7 +26,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst.handler_thread(0)
         self.assertEqual(inst.stop_count, 0)
         self.assertEqual(inst.active_count, 0)
-        self.assertEqual(inst.threads, set())
+        self.assertSetEqual(inst.threads, set())
         self.assertEqual(len(inst.logger.logged), 1)
 
     def test_set_thread_count_increase(self):
@@ -34,7 +34,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         L = []
         inst.start_new_thread = lambda *x: L.append(x)
         inst.set_thread_count(1)
-        self.assertEqual(L, [(inst.handler_thread, 0)])
+        self.assertListEqual(L, [(inst.handler_thread, 0)])
 
     def test_set_thread_count_increase_with_existing(self):
         inst = self._makeOne()
@@ -42,7 +42,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst.threads = {0}
         inst.start_new_thread = lambda *x: L.append(x)
         inst.set_thread_count(2)
-        self.assertEqual(L, [(inst.handler_thread, 1)])
+        self.assertListEqual(L, [(inst.handler_thread, 1)])
 
     def test_set_thread_count_decrease(self):
         inst = self._makeOne()
@@ -56,7 +56,7 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst.start_new_thread = lambda *x: L.append(x)
         inst.threads = {0}
         inst.set_thread_count(1)
-        self.assertEqual(L, [])
+        self.assertListEqual(L, [])
 
     def test_add_task_with_idle_threads(self):
         task = DummyTask()
@@ -82,23 +82,23 @@ class TestThreadedTaskDispatcher(unittest.TestCase):
         inst.logger = DummyLogger()
         task = DummyTask()
         inst.queue.append(task)
-        self.assertEqual(inst.shutdown(timeout=0.01), True)
-        self.assertEqual(
+        self.assertTrue(inst.shutdown(timeout=0.01))
+        self.assertListEqual(
             inst.logger.logged,
             [
                 "1 thread(s) still running",
                 "Canceling 1 pending task(s)",
             ],
         )
-        self.assertEqual(task.cancelled, True)
+        self.assertTrue(task.cancelled)
 
     def test_shutdown_no_threads(self):
         inst = self._makeOne()
-        self.assertEqual(inst.shutdown(timeout=0.01), True)
+        self.assertTrue(inst.shutdown(timeout=0.01))
 
     def test_shutdown_no_cancel_pending(self):
         inst = self._makeOne()
-        self.assertEqual(inst.shutdown(cancel_pending=False, timeout=0.01), False)
+        self.assertFalse(inst.shutdown(cancel_pending=False, timeout=0.01))
 
 
 class TestTask(unittest.TestCase):
@@ -135,8 +135,8 @@ class TestTask(unittest.TestCase):
         self.assertEqual(lines[1], b"Connection: close")
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
-        self.assertEqual(inst.close_on_finish, True)
-        self.assertTrue(("Connection", "close") in inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
+        self.assertIn(("Connection", "close"), inst.response_headers)
 
     def test_build_response_header_v10_keepalive_with_content_length(self):
         inst = self._makeOne()
@@ -153,7 +153,7 @@ class TestTask(unittest.TestCase):
         self.assertEqual(lines[2], b"Content-Length: 10")
         self.assertTrue(lines[3].startswith(b"Date:"))
         self.assertEqual(lines[4], b"Server: waitress")
-        self.assertEqual(inst.close_on_finish, False)
+        self.assertFalse(inst.close_on_finish)
 
     def test_build_response_header_v11_connection_closed_by_client(self):
         inst = self._makeOne()
@@ -168,8 +168,8 @@ class TestTask(unittest.TestCase):
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
         self.assertEqual(lines[4], b"Transfer-Encoding: chunked")
-        self.assertTrue(("Connection", "close") in inst.response_headers)
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertIn(("Connection", "close"), inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
 
     def test_build_response_header_v11_connection_keepalive_by_client(self):
         inst = self._makeOne()
@@ -184,8 +184,8 @@ class TestTask(unittest.TestCase):
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
         self.assertEqual(lines[4], b"Transfer-Encoding: chunked")
-        self.assertTrue(("Connection", "close") in inst.response_headers)
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertIn(("Connection", "close"), inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
 
     def test_build_response_header_v11_200_no_content_length(self):
         inst = self._makeOne()
@@ -199,8 +199,8 @@ class TestTask(unittest.TestCase):
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
         self.assertEqual(lines[4], b"Transfer-Encoding: chunked")
-        self.assertEqual(inst.close_on_finish, True)
-        self.assertTrue(("Connection", "close") in inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
+        self.assertIn(("Connection", "close"), inst.response_headers)
 
     def test_build_response_header_v11_204_no_content_length_or_transfer_encoding(self):
         # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
@@ -216,8 +216,8 @@ class TestTask(unittest.TestCase):
         self.assertEqual(lines[1], b"Connection: close")
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
-        self.assertEqual(inst.close_on_finish, True)
-        self.assertTrue(("Connection", "close") in inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
+        self.assertIn(("Connection", "close"), inst.response_headers)
 
     def test_build_response_header_v11_1xx_no_content_length_or_transfer_encoding(self):
         # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
@@ -233,8 +233,8 @@ class TestTask(unittest.TestCase):
         self.assertEqual(lines[1], b"Connection: close")
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
-        self.assertEqual(inst.close_on_finish, True)
-        self.assertTrue(("Connection", "close") in inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
+        self.assertIn(("Connection", "close"), inst.response_headers)
 
     def test_build_response_header_v11_304_no_content_length_or_transfer_encoding(self):
         # RFC 7230: MUST NOT send Transfer-Encoding or Content-Length
@@ -250,8 +250,8 @@ class TestTask(unittest.TestCase):
         self.assertEqual(lines[1], b"Connection: close")
         self.assertTrue(lines[2].startswith(b"Date:"))
         self.assertEqual(lines[3], b"Server: waitress")
-        self.assertEqual(inst.close_on_finish, True)
-        self.assertTrue(("Connection", "close") in inst.response_headers)
+        self.assertTrue(inst.close_on_finish)
+        self.assertIn(("Connection", "close"), inst.response_headers)
 
     def test_build_response_header_via_added(self):
         inst = self._makeOne()
@@ -297,7 +297,7 @@ class TestTask(unittest.TestCase):
         inst = self._makeOne()
         inst.response_headers = [("Content-Length", "70")]
         inst.remove_content_length_header()
-        self.assertEqual(inst.response_headers, [])
+        self.assertListEqual(inst.response_headers, [])
 
     def test_remove_content_length_header_with_other(self):
         inst = self._makeOne()
@@ -306,7 +306,7 @@ class TestTask(unittest.TestCase):
             ("Content-Type", "text/html"),
         ]
         inst.remove_content_length_header()
-        self.assertEqual(inst.response_headers, [("Content-Type", "text/html")])
+        self.assertListEqual(inst.response_headers, [("Content-Type", "text/html")])
 
     def test_start(self):
         inst = self._makeOne()
@@ -347,7 +347,7 @@ class TestTask(unittest.TestCase):
         inst.complete = True
         inst.write(b"abc")
         self.assertTrue(inst.channel.written)
-        self.assertEqual(inst.wrote_header, True)
+        self.assertTrue(inst.wrote_header)
 
     def test_write_start_response_uncalled(self):
         inst = self._makeOne()
@@ -369,7 +369,7 @@ class TestTask(unittest.TestCase):
         inst.logger = DummyLogger()
         inst.write(b"abc")
         self.assertTrue(inst.channel.written)
-        self.assertEqual(inst.logged_write_excess, True)
+        self.assertTrue(inst.logged_write_excess)
         self.assertEqual(len(inst.logger.logged), 1)
 
 
@@ -395,7 +395,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertTrue(inst.start_time)
         self.assertTrue(inst.close_on_finish)
         self.assertTrue(inst.channel.written)
-        self.assertEqual(inst.executed, True)
+        self.assertTrue(inst.executed)
 
     def test_service_server_raises_socket_error(self):
         import socket
@@ -446,7 +446,7 @@ class TestWSGITask(unittest.TestCase):
         self.assertTrue(inst.complete)
         self.assertEqual(inst.status, "200 OK")
         self.assertTrue(inst.channel.written)
-        self.assertFalse(("a", "b") in inst.response_headers)
+        self.assertNotIn(("a", "b"), inst.response_headers)
 
     def test_execute_app_calls_start_response_w_excinf_headers_written(self):
         def app(environ, start_response):
@@ -515,7 +515,7 @@ class TestWSGITask(unittest.TestCase):
         inst = self._makeOne()
         inst.channel.server.application = app
         inst.execute()
-        self.assertTrue(b"A: b\r\nA: a\r\nC: b\r\n" in inst.channel.written)
+        self.assertIn(b"A: b\r\nA: a\r\nC: b\r\n", inst.channel.written)
 
     def test_execute_bad_status_value(self):
         def app(environ, start_response):
@@ -564,7 +564,7 @@ class TestWSGITask(unittest.TestCase):
         inst = self._makeOne()
         inst.channel.server.application = app
         inst.execute()
-        self.assertEqual(inst.content_length, None)
+        self.assertIsNone(inst.content_length)
 
     def test_execute_app_returns_too_many_bytes(self):
         def app(environ, start_response):
@@ -575,7 +575,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(inst.close_on_finish)
         self.assertEqual(len(inst.logger.logged), 1)
 
     def test_execute_app_returns_too_few_bytes(self):
@@ -587,7 +587,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(inst.close_on_finish)
         self.assertEqual(len(inst.logger.logged), 1)
 
     def test_execute_app_head_with_content_length(self):
@@ -600,7 +600,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, False)
+        self.assertFalse(inst.close_on_finish)
         self.assertEqual(len(inst.logger.logged), 0)
 
     def test_execute_app_without_body_204_logged(self):
@@ -612,7 +612,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(inst.close_on_finish)
         self.assertNotIn(b"abc", inst.channel.written)
         self.assertNotIn(b"Content-Length", inst.channel.written)
         self.assertNotIn(b"Transfer-Encoding", inst.channel.written)
@@ -627,7 +627,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.logger = DummyLogger()
         inst.execute()
-        self.assertEqual(inst.close_on_finish, True)
+        self.assertTrue(inst.close_on_finish)
         self.assertNotIn(b"abc", inst.channel.written)
         self.assertNotIn(b"Content-Length", inst.channel.written)
         self.assertNotIn(b"Transfer-Encoding", inst.channel.written)
@@ -647,7 +647,7 @@ class TestWSGITask(unittest.TestCase):
         inst = self._makeOne()
         inst.channel.server.application = app
         inst.execute()
-        self.assertEqual(foo.closed, True)
+        self.assertTrue(foo.closed)
 
     def test_execute_app_returns_filewrapper_prepare_returns_True(self):
         from waitress.buffers import ReadOnlyFileBasedBuffer
@@ -663,7 +663,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.execute()
         self.assertTrue(inst.channel.written)  # header
-        self.assertEqual(inst.channel.otherdata, [app_iter])
+        self.assertListEqual(inst.channel.otherdata, [app_iter])
 
     def test_execute_app_returns_filewrapper_prepare_returns_True_nocl(self):
         from waitress.buffers import ReadOnlyFileBasedBuffer
@@ -679,7 +679,7 @@ class TestWSGITask(unittest.TestCase):
         inst.channel.server.application = app
         inst.execute()
         self.assertTrue(inst.channel.written)  # header
-        self.assertEqual(inst.channel.otherdata, [app_iter])
+        self.assertListEqual(inst.channel.otherdata, [app_iter])
         self.assertEqual(inst.content_length, 3)
 
     def test_execute_app_returns_filewrapper_prepare_returns_True_badcl(self):
@@ -698,14 +698,14 @@ class TestWSGITask(unittest.TestCase):
         inst.response_headers = [("Content-Length", "10")]
         inst.execute()
         self.assertTrue(inst.channel.written)  # header
-        self.assertEqual(inst.channel.otherdata, [app_iter])
+        self.assertListEqual(inst.channel.otherdata, [app_iter])
         self.assertEqual(inst.content_length, 3)
-        self.assertEqual(dict(inst.response_headers)["Content-Length"], "3")
+        self.assertIn(("Content-Length", "3"), inst.response_headers)
 
     def test_get_environment_already_cached(self):
         inst = self._makeOne()
-        inst.environ = object()
-        self.assertEqual(inst.get_environment(), inst.environ)
+        inst.environ = {}
+        self.assertDictEqual(inst.get_environment(), inst.environ)
 
     def test_get_environment_path_startswith_more_than_one_slash(self):
         inst = self._makeOne()
@@ -784,7 +784,7 @@ class TestWSGITask(unittest.TestCase):
         environ = inst.get_environment()
 
         # nail the keys of environ
-        self.assertEqual(
+        self.assertListEqual(
             sorted(environ.keys()),
             [
                 "CONTENT_LENGTH",
@@ -835,11 +835,11 @@ class TestWSGITask(unittest.TestCase):
         self.assertEqual(environ["wsgi.version"], (1, 0))
         self.assertEqual(environ["wsgi.url_scheme"], "http")
         self.assertEqual(environ["wsgi.errors"], sys.stderr)
-        self.assertEqual(environ["wsgi.multithread"], True)
-        self.assertEqual(environ["wsgi.multiprocess"], False)
-        self.assertEqual(environ["wsgi.run_once"], False)
+        self.assertTrue(environ["wsgi.multithread"])
+        self.assertFalse(environ["wsgi.multiprocess"])
+        self.assertFalse(environ["wsgi.run_once"])
         self.assertEqual(environ["wsgi.input"], "stream")
-        self.assertEqual(environ["wsgi.input_terminated"], True)
+        self.assertTrue(environ["wsgi.input_terminated"])
         self.assertEqual(inst.environ, environ)
 
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -32,41 +32,41 @@ if not sys.platform.startswith("win"):
         def test_readable(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.readable(), True)
+            self.assertTrue(inst.readable())
 
         def test_writable(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.writable(), False)
+            self.assertFalse(inst.writable())
 
         def test_handle_connect(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.handle_connect(), None)
+            self.assertIsNone(inst.handle_connect())
 
         def test_close(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.close(), None)
-            self.assertEqual(inst._closed, True)
+            self.assertIsNone(inst.close())
+            self.assertTrue(inst._closed)
 
         def test_handle_close(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.handle_close(), None)
-            self.assertEqual(inst._closed, True)
+            self.assertIsNone(inst.handle_close())
+            self.assertTrue(inst._closed)
 
         def test_pull_trigger_nothunk(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.pull_trigger(), None)
+            self.assertIsNone(inst.pull_trigger())
             r = os.read(inst._fds[0], 1)
             self.assertEqual(r, b"x")
 
         def test_pull_trigger_thunk(self):
             map = {}
             inst = self._makeOne(map)
-            self.assertEqual(inst.pull_trigger(True), None)
+            self.assertIsNone(inst.pull_trigger(True))
             self.assertEqual(len(inst.thunks), 1)
             r = os.read(inst._fds[0], 1)
             self.assertEqual(r, b"x")
@@ -75,14 +75,14 @@ if not sys.platform.startswith("win"):
             map = {}
             inst = self._makeOne(map)
             result = inst.handle_read()
-            self.assertEqual(result, None)
+            self.assertIsNone(result)
 
         def test_handle_read_no_socket_error(self):
             map = {}
             inst = self._makeOne(map)
             inst.pull_trigger()
             result = inst.handle_read()
-            self.assertEqual(result, None)
+            self.assertIsNone(result)
 
         def test_handle_read_thunk(self):
             map = {}
@@ -91,9 +91,9 @@ if not sys.platform.startswith("win"):
             L = []
             inst.thunks = [lambda: L.append(True)]
             result = inst.handle_read()
-            self.assertEqual(result, None)
-            self.assertEqual(L, [True])
-            self.assertEqual(inst.thunks, [])
+            self.assertIsNone(result)
+            self.assertListEqual(L, [True])
+            self.assertListEqual(inst.thunks, [])
 
         def test_handle_read_thunk_error(self):
             map = {}
@@ -106,6 +106,6 @@ if not sys.platform.startswith("win"):
             L = []
             inst.log_info = lambda *arg: L.append(arg)
             result = inst.handle_read()
-            self.assertEqual(result, None)
+            self.assertIsNone(result)
             self.assertEqual(len(L), 1)
-            self.assertEqual(inst.thunks, [])
+            self.assertListEqual(inst.thunks, [])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -56,7 +56,7 @@ class Test_unpack_rfc850(unittest.TestCase):
     def test_it(self):
         val = "Tuesday, 08-Feb-94 14:15:29 GMT"
         result = self._callFUT(val)
-        self.assertEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
+        self.assertTupleEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
 
 
 class Test_unpack_rfc_822(unittest.TestCase):
@@ -68,7 +68,7 @@ class Test_unpack_rfc_822(unittest.TestCase):
     def test_it(self):
         val = "Sun, 08 Feb 1994 14:15:29 GMT"
         result = self._callFUT(val)
-        self.assertEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
+        self.assertTupleEqual(result, (1994, 2, 8, 14, 15, 29, 0, 0, 0))
 
 
 class Test_find_double_newline(unittest.TestCase):

--- a/tests/test_wasyncore.py
+++ b/tests/test_wasyncore.py
@@ -454,15 +454,15 @@ class HelperFunctionTests(unittest.TestCase):
         # method causes the handle_error method to get called
         tr2 = crashingdummy()
         asyncore.read(tr2)
-        self.assertEqual(tr2.error_handled, True)
+        self.assertTrue(tr2.error_handled)
 
         tr2 = crashingdummy()
         asyncore.write(tr2)
-        self.assertEqual(tr2.error_handled, True)
+        self.assertTrue(tr2.error_handled)
 
         tr2 = crashingdummy()
         asyncore._exception(tr2)
-        self.assertEqual(tr2.error_handled, True)
+        self.assertTrue(tr2.error_handled)
 
     # asyncore.readwrite uses constants in the select module that
     # are not present in Windows systems (see this thread:
@@ -509,7 +509,7 @@ class HelperFunctionTests(unittest.TestCase):
 
         for flag, expectedattr in expected:
             tobj = testobj()
-            self.assertEqual(getattr(tobj, expectedattr), False)
+            self.assertFalse(getattr(tobj, expectedattr))
             asyncore.readwrite(tobj, flag)
 
             # Only the attribute modified by the routine we expect to be
@@ -526,9 +526,9 @@ class HelperFunctionTests(unittest.TestCase):
             # check that an exception other than ExitNow in the object handler
             # method causes the handle_error method to get called
             tr2 = crashingdummy()
-            self.assertEqual(tr2.error_handled, False)
+            self.assertFalse(tr2.error_handled)
             asyncore.readwrite(tr2, flag)
-            self.assertEqual(tr2.error_handled, True)
+            self.assertTrue(tr2.error_handled)
 
     def test_closeall(self):
         self.closeall_check(False)
@@ -545,7 +545,7 @@ class HelperFunctionTests(unittest.TestCase):
         for i in range(10):
             c = dummychannel()
             l.append(c)
-            self.assertEqual(c.socket.closed, False)
+            self.assertFalse(c.socket.closed)
             testmap[i] = c
 
         if usedefault:
@@ -561,7 +561,7 @@ class HelperFunctionTests(unittest.TestCase):
         self.assertEqual(len(testmap), 0)
 
         for c in l:
-            self.assertEqual(c.socket.closed, True)
+            self.assertTrue(c.socket.closed)
 
     def test_compact_traceback(self):
         try:
@@ -587,8 +587,8 @@ class DispatcherTests(unittest.TestCase):
 
     def test_basic(self):
         d = asyncore.dispatcher()
-        self.assertEqual(d.readable(), True)
-        self.assertEqual(d.writable(), True)
+        self.assertTrue(d.readable())
+        self.assertTrue(d.writable())
 
     def test_repr(self):
         d = asyncore.dispatcher()
@@ -601,7 +601,7 @@ class DispatcherTests(unittest.TestCase):
         logger = DummyLogger()
         inst.logger = logger
         inst.log_info("message", "warning")
-        self.assertEqual(logger.messages, [(logging.WARN, "message")])
+        self.assertListEqual(logger.messages, [(logging.WARN, "message")])
 
     def test_log(self):
         import logging
@@ -610,7 +610,7 @@ class DispatcherTests(unittest.TestCase):
         logger = DummyLogger()
         inst.logger = logger
         inst.log("message")
-        self.assertEqual(logger.messages, [(logging.DEBUG, "message")])
+        self.assertListEqual(logger.messages, [(logging.DEBUG, "message")])
 
     def test_unhandled(self):
         import logging
@@ -630,7 +630,7 @@ class DispatcherTests(unittest.TestCase):
             (logging.WARN, "unhandled write event"),
             (logging.WARN, "unhandled connect event"),
         ]
-        self.assertEqual(logger.messages, expected)
+        self.assertListEqual(logger.messages, expected)
 
     def test_strerror(self):
         # refers to bug #8573
@@ -639,7 +639,7 @@ class DispatcherTests(unittest.TestCase):
         if hasattr(os, "strerror"):
             self.assertEqual(err, os.strerror(errno.EPERM))
         err = asyncore._strerror(-1)
-        self.assertTrue(err != "")
+        self.assertNotEqual(err, "")
 
 
 @unittest.skipUnless(
@@ -1334,8 +1334,8 @@ class Test_poll(unittest.TestCase):
             result = self._callFUT(map=map)
         finally:
             wasyncore.time = old_time
-        self.assertEqual(result, None)
-        self.assertEqual(dummy_time.sleepvals, [0.0])
+        self.assertIsNone(result)
+        self.assertListEqual(dummy_time.sleepvals, [0.0])
 
     def test_select_raises_EINTR(self):
         # i read the mock.patch docs.  nerp.
@@ -1351,8 +1351,8 @@ class Test_poll(unittest.TestCase):
             result = self._callFUT(map=map)
         finally:
             wasyncore.select = old_select
-        self.assertEqual(result, None)
-        self.assertEqual(dummy_select.selected, [([0], [], [0], 0.0)])
+        self.assertIsNone(result)
+        self.assertListEqual(dummy_select.selected, [([0], [], [0], 0.0)])
 
     def test_select_raises_non_EINTR(self):
         # i read the mock.patch docs.  nerp.
@@ -1368,7 +1368,7 @@ class Test_poll(unittest.TestCase):
             self.assertRaises(select.error, self._callFUT, map=map)
         finally:
             wasyncore.select = old_select
-        self.assertEqual(dummy_select.selected, [([0], [], [0], 0.0)])
+        self.assertListEqual(dummy_select.selected, [([0], [], [0], 0.0)])
 
 
 class Test_poll2(unittest.TestCase):
@@ -1391,7 +1391,7 @@ class Test_poll2(unittest.TestCase):
             self._callFUT(map=map)
         finally:
             wasyncore.select = old_select
-        self.assertEqual(pollster.polled, [0.0])
+        self.assertListEqual(pollster.polled, [0.0])
 
     def test_select_raises_non_EINTR(self):
         # i read the mock.patch docs.  nerp.
@@ -1407,7 +1407,7 @@ class Test_poll2(unittest.TestCase):
             self.assertRaises(select.error, self._callFUT, map=map)
         finally:
             wasyncore.select = old_select
-        self.assertEqual(pollster.polled, [0.0])
+        self.assertListEqual(pollster.polled, [0.0])
 
 
 class Test_dispatcher(unittest.TestCase):
@@ -1461,7 +1461,7 @@ class Test_dispatcher(unittest.TestCase):
         sock.accept = accept
         inst = self._makeOne(sock=sock, map=map)
         result = inst.accept()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
     def test_accept_raise_unexpected_socketerror(self):
         sock = dummysocket()
@@ -1572,7 +1572,7 @@ class Test_dispatcher(unittest.TestCase):
         inst = self._makeOne(sock=sock, map=map)
         inst.accepting = True
         result = inst.handle_write_event()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
     def test_handle_error_gardenpath(self):
         sock = dummysocket()
@@ -1593,7 +1593,7 @@ class Test_dispatcher(unittest.TestCase):
         inst.log_info = log_info
         inst.handle_error()
         self.assertTrue(inst.close_handled)
-        self.assertEqual(inst.logged_info, ("error",))
+        self.assertTupleEqual(inst.logged_info, ("error",))
 
     def test_handle_close(self):
         sock = dummysocket()
@@ -1629,7 +1629,7 @@ class Test_close_all(unittest.TestCase):
         disp = DummyDispatcher(exc=socket.error(errno.EBADF))
         map = {0: disp}
         self._callFUT(map)
-        self.assertEqual(map, {})
+        self.assertDictEqual(map, {})
 
     def test_socketerror_on_close_non_ebadf(self):
         disp = DummyDispatcher(exc=socket.error(errno.EAGAIN))


### PR DESCRIPTION
The idea here is to give better error messages in case of failing tests.

There are no functional changes, though some of the checks are stricter or do proper type checks.