### PR TITLE
Trivial code cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 41"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 exclude = '''
 /(
   \.git

--- a/src/waitress/channel.py
+++ b/src/waitress/channel.py
@@ -349,7 +349,7 @@ class HTTPChannel(wasyncore.dispatcher):
                     raise ClientDisconnected
                 num_bytes = len(data)
 
-                if data.__class__ is ReadOnlyFileBasedBuffer:
+                if isinstance(data, ReadOnlyFileBasedBuffer):
                     # they used wsgi.file_wrapper
                     self.outbufs.append(data)
                     nextbuf = OverflowableBuffer(self.adj.outbuf_overflow)

--- a/src/waitress/server.py
+++ b/src/waitress/server.py
@@ -34,7 +34,7 @@ def create_server(
     _start=True,  # test shim
     _sock=None,  # test shim
     _dispatcher=None,  # test shim
-    **kw  # adjustments
+    **kw,  # adjustments
 ):
     """
     if __name__ == '__main__':
@@ -193,7 +193,7 @@ class BaseWSGIServer(wasyncore.dispatcher):
         adj=None,  # adjustments
         sockinfo=None,  # opaque object
         bind_socket=True,
-        **kw
+        **kw,
     ):
         if adj is None:
             adj = Adjustments(**kw)
@@ -387,7 +387,7 @@ if hasattr(socket, "AF_UNIX"):
             dispatcher=None,  # dispatcher
             adj=None,  # adjustments
             sockinfo=None,  # opaque object
-            **kw
+            **kw,
         ):
             if sockinfo is None:
                 sockinfo = (socket.AF_UNIX, socket.SOCK_STREAM, None, None)

--- a/src/waitress/task.py
+++ b/src/waitress/task.py
@@ -13,7 +13,6 @@
 ##############################################################################
 
 from collections import deque
-import socket
 import sys
 import threading
 import time
@@ -389,7 +388,7 @@ class WSGITask(Task):
 
             self.complete = True
 
-            if status.__class__ is not str:
+            if not isinstance(status, str):
                 raise AssertionError("status %s is not a string" % status)
             if "\n" in status or "\r" in status:
                 raise ValueError(
@@ -400,11 +399,11 @@ class WSGITask(Task):
 
             # Prepare the headers for output
             for k, v in headers:
-                if k.__class__ is not str:
+                if not isinstance(k, str):
                     raise AssertionError(
                         f"Header name {k!r} is not a string in {(k, v)!r}"
                     )
-                if v.__class__ is not str:
+                if not isinstance(v, str):
                     raise AssertionError(
                         f"Header value {v!r} is not a string in {(k, v)!r}"
                     )
@@ -437,7 +436,7 @@ class WSGITask(Task):
 
         can_close_app_iter = True
         try:
-            if app_iter.__class__ is ReadOnlyFileBasedBuffer:
+            if isinstance(app_iter, ReadOnlyFileBasedBuffer):
                 cl = self.content_length
                 size = app_iter.prepare(cl)
                 if size:

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -53,19 +53,14 @@ nor the 3.X asyncore; it is a version compatible with either 2.7 or 3.X.
 
 from errno import (
     EAGAIN,
-    EALREADY,
     EBADF,
     ECONNABORTED,
     ECONNRESET,
-    EINPROGRESS,
     EINTR,
-    EINVAL,
-    EISCONN,
     ENOTCONN,
     EPIPE,
     ESHUTDOWN,
     EWOULDBLOCK,
-    errorcode,
 )
 import logging
 import os
@@ -75,7 +70,7 @@ import sys
 import time
 import warnings
 
-from . import compat, utilities
+from . import utilities
 
 _DISCONNECTED = frozenset({ECONNRESET, ENOTCONN, ESHUTDOWN, ECONNABORTED, EPIPE, EBADF})
 

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -1,5 +1,4 @@
 import socket
-import sys
 import unittest
 import warnings
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,8 +1,6 @@
 import io
 import unittest
 
-import pytest
-
 
 class TestHTTPChannel(unittest.TestCase):
     def _makeOne(self, sock, addr, adj, map=None):

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -178,8 +178,6 @@ class TestChunkedReceiver(unittest.TestCase):
         self.assertEqual(inst.error.__class__, BadRequest)
 
     def test_received_multiple_chunks(self):
-        from waitress.utilities import BadRequest
-
         buf = DummyBuffer()
         inst = self._makeOne(buf)
         data = (
@@ -196,13 +194,11 @@ class TestChunkedReceiver(unittest.TestCase):
         )
         result = inst.received(data)
         self.assertEqual(result, len(data))
-        self.assertEqual(inst.completed, True)
+        self.assertTrue(inst.completed)
         self.assertEqual(b"".join(buf.data), b"Wikipedia in\r\n\r\nchunks.")
-        self.assertEqual(inst.error, None)
+        self.assertIsNone(inst.error)
 
     def test_received_multiple_chunks_split(self):
-        from waitress.utilities import BadRequest
-
         buf = DummyBuffer()
         inst = self._makeOne(buf)
         data1 = b"4\r\nWiki\r"
@@ -245,7 +241,7 @@ class TestChunkedReceiverParametrized:
         data = b"4;" + invalid_extension + b"\r\ntest\r\n"
         result = inst.received(data)
         assert result == len(data)
-        assert inst.error.__class__ == BadRequest
+        assert isinstance(inst.error, BadRequest)
         assert inst.error.body == "Invalid chunk extension"
 
     @pytest.mark.parametrize(
@@ -260,7 +256,7 @@ class TestChunkedReceiverParametrized:
         data = b"4;" + valid_extension + b"\r\ntest\r\n"
         result = inst.received(data)
         assert result == len(data)
-        assert inst.error == None
+        assert inst.error is None
 
     @pytest.mark.parametrize(
         "invalid_size", [b"0x04", b"+0x04", b"x04", b"+04", b" 04", b" 0x04"]
@@ -273,7 +269,7 @@ class TestChunkedReceiverParametrized:
         data = invalid_size + b"\r\ntest\r\n"
         result = inst.received(data)
         assert result == len(data)
-        assert inst.error.__class__ == BadRequest
+        assert isinstance(inst.error, BadRequest)
         assert inst.error.body == "Invalid chunk size"
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -398,7 +398,6 @@ if hasattr(socket, "AF_UNIX"):
             from waitress.server import (
                 BaseWSGIServer,
                 MultiSocketServer,
-                TcpWSGIServer,
                 UnixWSGIServer,
             )
 

--- a/tests/test_wasyncore.py
+++ b/tests/test_wasyncore.py
@@ -4,7 +4,6 @@ import errno
 from errno import EALREADY, EINPROGRESS, EINVAL, EISCONN, EWOULDBLOCK, errorcode
 import functools
 import gc
-from io import BytesIO
 import os
 import re
 import select


### PR DESCRIPTION
This is mostly stuff picked up by `ruff check --fix` with some extra fixes to the type checking.

A few assertion clean-ups leaked across from #447, but I don't think that's too big a deal.