### PR TITLE
Timeout functional tests

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -5,8 +5,6 @@
 - Anticipate multivalue and single-value-only headers in request headers in
   parser.py.
 
-- Timeout functests.
-
 - Complex pipelining functests (with intermediate connection: close).
 
 - Killthreads support.

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ where=src
 [options.extras_require]
 testing =
     pytest
+    pytest-timeout
     pytest-cov
     coverage>=5.0
 
@@ -61,6 +62,7 @@ docs =
     pylons-sphinx-themes>=1.0.9
 
 [tool:pytest]
+timeout = 30
 python_files = test_*.py
 # For the benefit of test_wasyncore.py
 python_classes = Test*

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -97,11 +97,8 @@ class SubprocessTests:
             self.proc.terminate()
         self.sock.close()
         # This give us one FD back ...
-        self.proc.join(timeout=5)
-        if self.proc.is_alive():
-            self.proc.terminate()
-        else:
-            self.proc.close()
+        self.proc.join()
+        self.proc.close()
         self.queue.close()
         self.queue.join_thread()
 
@@ -166,10 +163,9 @@ class SleepyThreadTests(TcpTests, unittest.TestCase):
         time.sleep(3)
 
         for proc in procs:
-            proc.poll()
             if proc.returncode is not None:  # pragma: no cover
                 proc.terminate()
-            proc.wait(timeout=5)
+            proc.wait()
         # the notsleepy response should always be first returned (it sleeps
         # for 2 seconds, then returns; the notsleepy response should be
         # processed in the meantime)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -98,7 +98,10 @@ class SubprocessTests:
         self.sock.close()
         # This give us one FD back ...
         self.proc.join(timeout=5)
-        self.proc.close()
+        if self.proc.is_alive():
+            self.proc.terminate()
+        else:
+            self.proc.close()
         self.queue.close()
         self.queue.join_thread()
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -97,7 +97,7 @@ class SubprocessTests:
             self.proc.terminate()
         self.sock.close()
         # This give us one FD back ...
-        self.proc.join()
+        self.proc.join(timeout=5)
         self.proc.close()
         self.queue.close()
         self.queue.join_thread()
@@ -163,9 +163,10 @@ class SleepyThreadTests(TcpTests, unittest.TestCase):
         time.sleep(3)
 
         for proc in procs:
+            proc.poll()
             if proc.returncode is not None:  # pragma: no cover
                 proc.terminate()
-            proc.wait()
+            proc.wait(timeout=5)
         # the notsleepy response should always be first returned (it sleeps
         # for 2 seconds, then returns; the notsleepy response should be
         # processed in the meantime)


### PR DESCRIPTION
If the functional tests don't exist after five seconds of waiting on them, they should be killed. This also uses [pytest-timeout](https://pypi.org/project/pytest-timeout/) to impose a maximum runtime of 30secs on any test in the test suite.

Hopefully this should prevent tests from hanging.