### PR TITLE
Add an --app= flag for specifying the WSGI application

### DIFF
--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -20,6 +20,10 @@ Is equivalent to::
 
     waitress-serve --port=8041 --url-scheme=https myapp:wsgifunc
 
+Or:
+
+    waitress-serve --port=8041 --url-scheme=https --app=myapp:wsgifunc
+
 The full argument list is :ref:`given below <invocation>`.
 
 Boolean arguments are represented by flags. If you wish to explicitly set a
@@ -64,12 +68,18 @@ Invocation
 
 Usage::
 
-    waitress-serve [OPTS] MODULE:OBJECT
+    waitress-serve [OPTS] [MODULE:OBJECT]
 
 Common options:
 
 ``--help``
     Show this information.
+
+``--app=MODULE:OBJECT``
+    Run the given callable object the WSGI application.
+
+    You can specify the WSGI application using this flag or as a positional
+    argument.
 
 ``--call``
     Call the given object to get the WSGI application.

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -480,6 +480,8 @@ class Adjustments:
                 kw[param] = "false"
             elif param in ("help", "call"):
                 kw[param] = True
+            elif param == "app":
+                kw[param] = value
             elif cls._param_map[param] is asbool:
                 kw[param] = "true"
             else:

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -505,7 +505,9 @@ class Adjustments:
             try:
                 kw["app"] = pkgutil.resolve_name(app)
             except (ValueError, ImportError, AttributeError) as exc:
-                raise AppResolutionError(f"Cannot import WSGI application '{app}': {exc}")
+                raise AppResolutionError(
+                    f"Cannot import WSGI application '{app}': {exc}",
+                )
             if kw["call"]:
                 kw["app"] = kw["app"]()
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -505,7 +505,7 @@ class Adjustments:
             try:
                 kw["app"] = pkgutil.resolve_name(app)
             except (ValueError, ImportError, AttributeError) as exc:
-                raise AppResolutionError(f"Cannot import WSGI application: {exc}")
+                raise AppResolutionError(f"Cannot import WSGI application '{app}': {exc}")
             if kw["call"]:
                 kw["app"] = kw["app"]()
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -459,9 +459,12 @@ class Adjustments:
             else:
                 long_opts.append(opt + "=")
 
+        long_opts.append("app=")
+
         kw = {
             "help": False,
             "call": False,
+            "app": None,
         }
 
         opts, args = getopt.getopt(argv, "", long_opts)
@@ -481,6 +484,9 @@ class Adjustments:
                 kw[param] = "true"
             else:
                 kw[param] = value
+
+        if kw["app"] is None and len(args) > 0:
+            kw["app"] = args.pop(0)
 
         return kw, args
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -112,6 +112,9 @@ def resolve_wsgi_app(app_name, call=False):
 class Adjustments:
     """This class contains tunable parameters."""
 
+    # If you add new parameters, be sure to update the following files:
+    #  * src/arguments.rst (waitress.serve)
+    #  * src/waitress/runner.py and src/runner.rst (CLI documentation)
     _params = (
         ("host", str),
         ("port", int),

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -29,12 +29,18 @@ from waitress.utilities import logger
 HELP = """\
 Usage:
 
-    {0} [OPTS] MODULE:OBJECT
+    {0} [OPTS] [MODULE:OBJECT]
 
 Standard options:
 
     --help
         Show this information.
+
+    --app=MODULE:OBJECT
+        Run the given callable object the WSGI application.
+
+        You can specify the WSGI application using this flag or as a positional
+        argument.
 
     --call
         Call the given object to get the WSGI application.

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -18,6 +18,7 @@ import logging
 import os
 import os.path
 import sys
+import traceback
 
 from waitress import serve
 from waitress.adjustments import Adjustments, AppResolutionError
@@ -289,8 +290,12 @@ def run(argv=sys.argv, _serve=serve):
 
     try:
         kw = Adjustments.parse_args(argv[1:])
-    except (getopt.GetoptError, AppResolutionError) as exc:
+    except getopt.GetoptError as exc:
         show_help(sys.stderr, name, str(exc))
+        return 1
+    except AppResolutionError as exc:
+        show_help(sys.stderr, name, str(exc))
+        traceback.print_exc(file=sys.stderr)
         return 1
 
     if kw["help"]:

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -283,23 +283,6 @@ def show_help(stream, name, error=None):  # pragma: no cover
     print(HELP.format(name), file=stream)
 
 
-def show_exception(stream):
-    exc_type, exc_value = sys.exc_info()[:2]
-    args = getattr(exc_value, "args", None)
-    print(
-        ("There was an exception ({}) importing your module.\n").format(
-            exc_type.__name__,
-        ),
-        file=stream,
-    )
-    if args:
-        print("It had these arguments: ", file=stream)
-        for idx, arg in enumerate(args, start=1):
-            print(f"{idx}. {arg}\n", file=stream)
-    else:
-        print("It had no arguments.", file=stream)
-
-
 def run(argv=sys.argv, _serve=serve):
     """Command line runner."""
     name = os.path.basename(argv[0])
@@ -332,7 +315,6 @@ def run(argv=sys.argv, _serve=serve):
         app = pkgutil.resolve_name(kw["app"])
     except (ValueError, ImportError, AttributeError) as exc:
         show_help(sys.stderr, name, str(exc))
-        show_exception(sys.stderr)
         return 1
     if kw["call"]:
         app = app()

--- a/src/waitress/runner.py
+++ b/src/waitress/runner.py
@@ -308,8 +308,8 @@ def run(argv=sys.argv, _serve=serve):
         show_help(sys.stdout, name)
         return 0
 
-    if len(args) != 1:
-        show_help(sys.stderr, name, "Specify one application only")
+    if kw["app"] is None:
+        show_help(sys.stderr, name, "Specify an application")
         return 1
 
     # set a default level for the logger only if it hasn't been set explicitly
@@ -323,7 +323,7 @@ def run(argv=sys.argv, _serve=serve):
 
     # Get the WSGI function.
     try:
-        app = pkgutil.resolve_name(args[0])
+        app = pkgutil.resolve_name(kw["app"])
     except (ValueError, ImportError, AttributeError) as exc:
         show_help(sys.stderr, name, str(exc))
         show_exception(sys.stderr)
@@ -332,7 +332,7 @@ def run(argv=sys.argv, _serve=serve):
         app = app()
 
     # These arguments are specific to the runner, not waitress itself.
-    del kw["call"], kw["help"]
+    del kw["call"], kw["help"], kw["app"]
 
     _serve(app, **kw)
     return 0

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -414,6 +414,16 @@ class TestCLI(unittest.TestCase):
         self.assertDictEqual(opts, {"call": True, "help": True, "app": None})
         self.assertSequenceEqual(args, [])
 
+    def test_app_flag(self):
+        opts, args = self.parse(["--app=fred:wilma", "barney:betty"])
+        self.assertEqual(opts["app"], "fred:wilma")
+        self.assertSequenceEqual(args, ["barney:betty"])
+
+    def test_app_arg(self):
+        opts, args = self.parse(["barney:betty"])
+        self.assertEqual(opts["app"], "barney:betty")
+        self.assertSequenceEqual(args, [])
+
     def test_positive_boolean(self):
         opts, args = self.parse(["--expose-tracebacks"])
         self.assertDictContainsSubset({"expose_tracebacks": "true"}, opts)

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -396,22 +396,22 @@ class TestCLI(unittest.TestCase):
 
     def test_noargs(self):
         opts, args = self.parse([])
-        self.assertDictEqual(opts, {"call": False, "help": False})
+        self.assertDictEqual(opts, {"call": False, "help": False, "app": None})
         self.assertSequenceEqual(args, [])
 
     def test_help(self):
         opts, args = self.parse(["--help"])
-        self.assertDictEqual(opts, {"call": False, "help": True})
+        self.assertDictEqual(opts, {"call": False, "help": True, "app": None})
         self.assertSequenceEqual(args, [])
 
     def test_call(self):
         opts, args = self.parse(["--call"])
-        self.assertDictEqual(opts, {"call": True, "help": False})
+        self.assertDictEqual(opts, {"call": True, "help": False, "app": None})
         self.assertSequenceEqual(args, [])
 
     def test_both(self):
         opts, args = self.parse(["--call", "--help"])
-        self.assertDictEqual(opts, {"call": True, "help": True})
+        self.assertDictEqual(opts, {"call": True, "help": True, "app": None})
         self.assertSequenceEqual(args, [])
 
     def test_positive_boolean(self):

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -395,48 +395,57 @@ class TestCLI(unittest.TestCase):
         self.assertTrue(set(subset.items()) <= set(dictionary.items()))
 
     def test_noargs(self):
-        opts, args = self.parse([])
-        self.assertDictEqual(opts, {"call": False, "help": False, "app": None})
-        self.assertSequenceEqual(args, [])
+        from waitress.adjustments import AppResolutionError
+
+        self.assertRaises(AppResolutionError, self.parse, [])
 
     def test_help(self):
-        opts, args = self.parse(["--help"])
-        self.assertDictEqual(opts, {"call": False, "help": True, "app": None})
-        self.assertSequenceEqual(args, [])
-
-    def test_call(self):
-        opts, args = self.parse(["--call"])
-        self.assertDictEqual(opts, {"call": True, "help": False, "app": None})
-        self.assertSequenceEqual(args, [])
-
-    def test_both(self):
-        opts, args = self.parse(["--call", "--help"])
-        self.assertDictEqual(opts, {"call": True, "help": True, "app": None})
-        self.assertSequenceEqual(args, [])
+        opts = self.parse(["--help"])
+        self.assertDictEqual(opts, {"help": True, "app": None})
 
     def test_app_flag(self):
-        opts, args = self.parse(["--app=fred:wilma", "barney:betty"])
-        self.assertEqual(opts["app"], "fred:wilma")
-        self.assertSequenceEqual(args, ["barney:betty"])
+        from tests.fixtureapps import runner as _apps
+
+        opts = self.parse(["--app=tests.fixtureapps.runner:app"])
+        self.assertEqual(opts["app"], _apps.app)
+
+    def test_call(self):
+        from tests.fixtureapps import runner as _apps
+
+        opts = self.parse(["--app=tests.fixtureapps.runner:returns_app", "--call"])
+        self.assertEqual(opts["app"], _apps.app)
 
     def test_app_arg(self):
-        opts, args = self.parse(["barney:betty"])
-        self.assertEqual(opts["app"], "barney:betty")
-        self.assertSequenceEqual(args, [])
+        from tests.fixtureapps import runner as _apps
+
+        opts = self.parse(["tests.fixtureapps.runner:app"])
+        self.assertEqual(opts["app"], _apps.app)
+
+    def test_excess(self):
+        from waitress.adjustments import AppResolutionError
+
+        self.assertRaises(
+            AppResolutionError,
+            self.parse,
+            ["tests.fixtureapps.runner:app", "tests.fixtureapps.runner:app"],
+        )
 
     def test_positive_boolean(self):
-        opts, args = self.parse(["--expose-tracebacks"])
+        opts = self.parse(["--expose-tracebacks", "tests.fixtureapps.runner:app"])
         self.assertDictContainsSubset({"expose_tracebacks": "true"}, opts)
-        self.assertSequenceEqual(args, [])
 
     def test_negative_boolean(self):
-        opts, args = self.parse(["--no-expose-tracebacks"])
+        opts = self.parse(["--no-expose-tracebacks", "tests.fixtureapps.runner:app"])
         self.assertDictContainsSubset({"expose_tracebacks": "false"}, opts)
-        self.assertSequenceEqual(args, [])
 
     def test_cast_params(self):
-        opts, args = self.parse(
-            ["--host=localhost", "--port=80", "--unix-socket-perms=777"]
+        opts = self.parse(
+            [
+                "--host=localhost",
+                "--port=80",
+                "--unix-socket-perms=777",
+                "tests.fixtureapps.runner:app",
+            ]
         )
         self.assertDictContainsSubset(
             {
@@ -446,28 +455,25 @@ class TestCLI(unittest.TestCase):
             },
             opts,
         )
-        self.assertSequenceEqual(args, [])
 
     def test_listen_params(self):
-        opts, args = self.parse(
+        opts = self.parse(
             [
                 "--listen=test:80",
+                "tests.fixtureapps.runner:app",
             ]
         )
-
         self.assertDictContainsSubset({"listen": " test:80"}, opts)
-        self.assertSequenceEqual(args, [])
 
     def test_multiple_listen_params(self):
-        opts, args = self.parse(
+        opts = self.parse(
             [
                 "--listen=test:80",
                 "--listen=test:8080",
+                "tests.fixtureapps.runner:app",
             ]
         )
-
         self.assertDictContainsSubset({"listen": " test:80 test:8080"}, opts)
-        self.assertSequenceEqual(args, [])
 
     def test_bad_param(self):
         import getopt

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,10 +21,10 @@ class Test_run(unittest.TestCase):
         self.match_output(["--help"], 0, "^Usage:\n\n    waitress-serve")
 
     def test_no_app(self):
-        self.match_output([], 1, "^Error: Specify one application only")
+        self.match_output([], 1, "^Error: Specify an application")
 
     def test_multiple_apps_app(self):
-        self.match_output(["a:a", "b:b"], 1, "^Error: Specify one application only")
+        self.match_output(["a:a", "b:b"], 1, "^Error: No module named 'a'")
 
     def test_bad_apps_app(self):
         self.match_output(["a"], 1, "^Error: No module named 'a'")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -32,16 +32,6 @@ class Test_run(unittest.TestCase):
     def test_bad_app_module(self):
         self.match_output(["nonexistent:a"], 1, "^Error: No module named 'nonexistent'")
 
-        self.match_output(
-            ["nonexistent:a"],
-            1,
-            (
-                r"There was an exception \((ImportError|ModuleNotFoundError)\) "
-                "importing your module.\n\nIt had these arguments: \n"
-                "1. No module named '?nonexistent'?"
-            ),
-        )
-
     def test_cwd_added_to_path(self):
         def null_serve(app, **kw):
             pass
@@ -94,37 +84,6 @@ class Test_run(unittest.TestCase):
             "tests.fixtureapps.runner:returns_app",
         ]
         self.assertEqual(runner.run(argv=argv, _serve=check_server), 0)
-
-
-class Test_helper(unittest.TestCase):
-    def test_exception_logging(self):
-        from waitress.runner import show_exception
-
-        regex = (
-            r"There was an exception \(ImportError\) importing your module."
-            r"\n\nIt had these arguments: \n1. My reason"
-        )
-
-        with capture() as captured:
-            try:
-                raise ImportError("My reason")
-            except ImportError:
-                self.assertIsNone(show_exception(sys.stderr))
-            self.assertRegex(captured.getvalue(), regex)
-        captured.close()
-
-        regex = (
-            r"There was an exception \(ImportError\) importing your module."
-            r"\n\nIt had no arguments."
-        )
-
-        with capture() as captured:
-            try:
-                raise ImportError
-            except ImportError:
-                self.assertIsNone(show_exception(sys.stderr))
-            self.assertRegex(captured.getvalue(), regex)
-        captured.close()
 
 
 @contextlib.contextmanager

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -24,13 +24,14 @@ class Test_run(unittest.TestCase):
         self.match_output([], 1, "^Error: Specify an application")
 
     def test_multiple_apps_app(self):
-        self.match_output(["a:a", "b:b"], 1, "^Error: No module named 'a'")
+        self.match_output(["a:a", "b:b"], 1, "^Error: Provide only one WSGI app")
+        self.match_output(["--app=a:a", "b:b"], 1, "^Error: Provide only one WSGI app")
 
     def test_bad_apps_app(self):
-        self.match_output(["a"], 1, "^Error: No module named 'a'")
+        self.match_output(["a"], 1, "No module named 'a'")
 
     def test_bad_app_module(self):
-        self.match_output(["nonexistent:a"], 1, "^Error: No module named 'nonexistent'")
+        self.match_output(["nonexistent:a"], 1, "No module named 'nonexistent'")
 
     def test_cwd_added_to_path(self):
         def null_serve(app, **kw):
@@ -53,7 +54,7 @@ class Test_run(unittest.TestCase):
         self.match_output(
             ["tests.fixtureapps.runner:a"],
             1,
-            "^Error: module 'tests.fixtureapps.runner' has no attribute 'a'",
+            "module 'tests.fixtureapps.runner' has no attribute 'a'",
         )
 
     def test_simple_call(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -91,8 +91,10 @@ def capture():
     from io import StringIO
 
     fd = StringIO()
+    old_stdout, old_stderr = sys.stdout, sys.stderr
     sys.stdout = fd
     sys.stderr = fd
-    yield fd
-    sys.stdout = sys.__stdout__
-    sys.stderr = sys.__stderr__
+    try:
+        yield fd
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr


### PR DESCRIPTION
This is essentially a less-invasive version of #441. As with that PR, this PR adds support for a `--app` flag for specifying the WSGI app to run. Unlike that one, it maintains the getopt-based implementation. There's certainly some value in moving to argparse at some point, but it'd need to integrate properly with the `Adjustments` class.

Closes #439, closes #441.

Some incidental changes that grew out of this:

* The `capture()` context manager is now more well-behaved as it respects the previous values of `sys.stderr` and `sys.stdin`, and restores them in a `finally` block if there's an exception.
* `Adjustments.parse_cli()` is now responsible for resolving the app descriptor. This forces some of the tests to be a bit more realistic.
* A stacktrace is now printed if there's an issue resolving an app descriptor, which should be useful if, say, and ImportError was caused secondarily by a different exception in the app itself. This should keep the spirit of `show_exception`, while leaning on the standard library more.