### PR TITLE
When Transfer-Encoding is set, and Content-Length, close connection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+Unreleased
+----------
+
+Bugfix
+~~~~~~
+
+- When encountering a request that has both Content-Length set and
+  Transfer-Encoding of chunked we now close the connection after it is
+  completed to comply with the requirements of RFC9112. See
+  https://github.com/Pylons/waitress/pull/475 and
+  https://github.com/Pylons/waitress/issues/464
+
 3.0.2 (2024-11-16)
 ------------------
 

--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -307,6 +307,13 @@ class HTTPRequestParser:
                 self.chunked = True
                 buf = OverflowableBuffer(self.adj.inbuf_overflow)
                 self.body_rcv = ChunkedReceiver(buf)
+
+                # RFC9112 states that we need to close the connection if the
+                # Transfer-Encoding is set, AND a Content-Length is provided.
+                cl = headers.pop("CONTENT_LENGTH", None)
+                if cl is not None:
+                    self.connection_close = True
+
             elif encodings:  # pragma: nocover
                 raise TransferEncodingNotImplemented(
                     "Transfer-Encoding requested is not supported."

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -236,6 +236,13 @@ class TestHTTPRequestParser(unittest.TestCase):
         self.parser.parse_header(data)
         self.assertEqual(self.parser.body_rcv.__class__.__name__, "ChunkedReceiver")
 
+    def test_parse_header_11_te_chunked_with_cl_close_connection(self):
+        # NB: test that capitalization of header value is unimportant
+        data = b"GET /foobar HTTP/1.1\r\ntransfer-encoding: chunked\r\ncontent-length: 10\r\n"
+        self.parser.parse_header(data)
+        self.assertEqual(self.parser.body_rcv.__class__.__name__, "ChunkedReceiver")
+        self.assertEqual(self.parser.connection_close, True)
+
     def test_parse_header_transfer_encoding_invalid(self):
         data = b"GET /foobar HTTP/1.1\r\ntransfer-encoding: gzip\r\n"
 


### PR DESCRIPTION
RFC9112 adds an additional requirement when parsing a request that has both content-length and transfer-encoding set, which is that the connection should be closed after a single use to avoid potential pitfalls with request smuggling/parser desync between multiple implementations.

So now we check to see if the content-length was also set, and if so, we close the connection after the request is completed.

Closes https://github.com/Pylons/waitress/issues/464