### PR TITLE
Reject requests with duplicate Content-Type

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -152,3 +152,5 @@ Contributors
 - Simon King, 2024-11-12
 
 - Arun Raghunath, 2026-03-13
+
+- Rui Xi, 2026-03-20

--- a/src/waitress/parser.py
+++ b/src/waitress/parser.py
@@ -34,7 +34,7 @@ from waitress.utilities import (
 )
 
 # A list of HEADERS that must not be duplicated per RFC 9112
-HEADERS_NO_DUPLICATES = frozenset({"HOST", "CONTENT_LENGTH"})
+SINGLETON_FIELDS = frozenset({"HOST", "CONTENT_LENGTH", "CONTENT_TYPE"})
 
 
 def unquote_bytes_to_wsgi(bytestring):
@@ -242,7 +242,7 @@ class HTTPRequestParser:
             key1 = key.upper().replace(b"-", b"_").decode("latin-1")
 
             # Reject duplicate 'Host' headers as per RFC 9112 section 3.2
-            if key1 in HEADERS_NO_DUPLICATES and key1 in headers:
+            if key1 in SINGLETON_FIELDS and key1 in headers:
                 raise ParsingError(f"Duplicate header: {key.decode('latin-1')}")
 
             # If a header already exists, we append subsequent values

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -81,6 +81,14 @@ class TestHTTPRequestParser(unittest.TestCase):
         self.assertIsInstance(self.parser.error, BadRequest)
         self.assertTrue(self.parser.error.body.startswith("Duplicate header:"))
 
+    def test_received_duplicate_content_type_header(self):
+        data = b"GET / HTTP/1.1\r\nHost: example.com\r\nContent-Type: text/plain\r\nContent-Type: text/html\r\n\r\n"
+        result = self.parser.received(data)
+        self.assertEqual(result, len(data))
+        self.assertTrue(self.parser.completed)
+        self.assertIsInstance(self.parser.error, BadRequest)
+        self.assertTrue(self.parser.error.body.startswith("Duplicate header:"))
+
     def test_received_bad_transfer_encoding(self):
         data = (
             b"GET /foobar HTTP/1.1\r\n"


### PR DESCRIPTION
Also rename header lists to `SINGLETON_FIELDS`, as it is an actual word in RFC9110 glossary index.

Fixes #466 
