### PR TITLE
Enabled logging of failed port bind

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,11 @@ Bugfix
   https://github.com/Pylons/waitress/pull/475 and
   https://github.com/Pylons/waitress/issues/464
 
+- Enabled logging of failed port bind in `waysyncore.py:dispatcher.bind` to aid
+  in debugging application bind failures.  See
+  https://github.com/Pylons/waitress/issues/471
+
+
 3.0.2 (2024-11-16)
 ------------------
 

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -370,8 +370,14 @@ class dispatcher:
         return self.socket.listen(num)
 
     def bind(self, addr):
+        # self.logger.log(logging.DEBUG, "Attempting to bind to: %s" % addr)
         self.addr = addr
-        return self.socket.bind(addr)
+        try:
+            return self.socket.bind(addr)
+        except Exception as exc:
+            self.logger.log(logging.CRITICAL, "Failed bind to: %s" % str(addr))
+            self.logger.log(logging.CRITICAL, "Exception raised: %s" % str(exc))
+            raise
 
     def accept(self):
         # XXX can return either an address pair or None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import errno
 import socket
+import sys
 import unittest
 
 dummy_app = object()
@@ -310,6 +311,42 @@ class TestWSGIServer(unittest.TestCase):
         self.assertTrue(sockets[0].accepted)
         self.assertListEqual(innersock.opts, [("level", "optname", "value")])
         self.assertListEqual(L, [(inst, innersock, None, inst.adj)])
+
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "This test is not supported on Windows"
+    )
+    def test_port_bind_failure_logging(self):
+        # ensure the address is logged on a failed port bind
+
+        # create a first app correctly
+        inst_a = self._makeOne(port=8080)
+
+        # Ensure a second app correctly binds to a different host+port
+        inst_b = self._makeOne(port=8081)
+
+        # a third app should fail the bind to the fist app's host+port
+        with self.assertLogs("waitress", level="ERROR") as cm_log:
+            with self.assertRaises(OSError) as cm:
+                inst_c = self._makeOne(port=8080)
+            self.assertTrue(
+                ("[Errno 48] Address already in use" == str(cm.exception))
+                or ("[Errno 98] Address already in use" == str(cm.exception))
+            )
+
+        self.assertIn(
+            "CRITICAL:waitress:Failed bind to: ('127.0.0.1', 8080)",
+            cm_log.output,
+        )
+        self.assertTrue(
+            (
+                "CRITICAL:waitress:Exception raised: [Errno 48] Address already in use"
+                in cm_log.output
+            )
+            or (
+                "CRITICAL:waitress:Exception raised: [Errno 98] Address already in use"
+                in cm_log.output
+            )
+        )
 
 
 if hasattr(socket, "AF_UNIX"):


### PR DESCRIPTION
This PR enables logging on failed port binds.  See #471

There is a test, but it does not run on windows.

After doing a lot of testing on the Github CI system, Windows does not appear to raise an exception here (though it should, according to docs.)

Note the tests run against two possible OsError codes.  Either 48 or 98 is raised, depending on the python version and os.  

The logging was easy.  Getting the testing right, and merging against main was not ;)