### PR TITLE
Enabled logging of failed port bind (v2)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,11 @@ Bugfix
   https://github.com/Pylons/waitress/pull/475 and
   https://github.com/Pylons/waitress/issues/464
 
+- Enabled logging of failed port bind in `waysyncore.py:dispatcher.bind` to aid
+  in debugging application bind failures.  See
+  https://github.com/Pylons/waitress/issues/471
+
+
 3.0.2 (2024-11-16)
 ------------------
 

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -370,13 +370,11 @@ class dispatcher:
         return self.socket.listen(num)
 
     def bind(self, addr):
-        # self.logger.log(logging.DEBUG, "Attempting to bind to: %s" % addr)
         self.addr = addr
         try:
             return self.socket.bind(addr)
         except Exception as exc:
-            self.logger.log(logging.CRITICAL, "Failed bind to: %s" % str(addr))
-            self.logger.log(logging.CRITICAL, "Exception raised: %s" % str(exc))
+            self.logger.critical("Failed bind to: `%s` : `%s`" % (str(addr), str(exc)))
             raise
 
     def accept(self):

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -370,8 +370,14 @@ class dispatcher:
         return self.socket.listen(num)
 
     def bind(self, addr):
+        # self.logger.log(logging.DEBUG, "Attempting to bind to: %s" % addr)
         self.addr = addr
-        return self.socket.bind(addr)
+        try:
+            return self.socket.bind(addr)
+        except Exception as exc:
+            self.logger.log(logging.CRITICAL, "Failed bind to: %s" % str(addr))
+            self.logger.log(logging.CRITICAL, "Exception raised: %s" % str(exc))
+            raise
 
     def accept(self):
         # XXX can return either an address pair or None

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -374,7 +374,7 @@ class dispatcher:
         try:
             return self.socket.bind(addr)
         except Exception as exc:
-            self.logger.critical("Failed bind to: `%s` : `%s`" % (str(addr), str(exc)))
+            self.logger.critical("Failed bind to: `%s` : `%s`", str(addr), exc)
             raise
 
     def accept(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -341,6 +341,8 @@ class TestWSGIServer(unittest.TestCase):
         Ensure the address is logged on a failed port bind.
 
         This test was developed for #471 - logging a failed bind.
+
+        This test will leave a socket open until #480 is fixed.
         """
 
         # create a first app correctly
@@ -352,6 +354,7 @@ class TestWSGIServer(unittest.TestCase):
         # a third app should fail the bind to the fist app's host+port
         with self.assertLogs("waitress", level="ERROR") as cm_log:
             with self.assertRaises(OSError) as cm:
+                # this line will trigger #480 and leave a socket open
                 inst_c = self._makeOne(port=8080)
             self.assertEqual(cm.exception.errno, errno.EADDRINUSE)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import errno
+import os
 import socket
 import sys
 from typing import TYPE_CHECKING, List, Union
@@ -362,7 +363,7 @@ class TestWSGIServer(unittest.TestCase):
         self.assertIn(
             "CRITICAL:waitress:"
             "Failed bind to: `('127.0.0.1', 8080)` : "
-            "`[Errno %s] Address already in use`" % errno.EADDRINUSE,
+            f"`[Errno {errno.EADDRINUSE}] {os.strerror(errno.EADDRINUSE)}`",
             cm_log.output,
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 dummy_app = object()
 
+
 class TestWSGIServer(unittest.TestCase):
 
     # maintain a list of instantiated servers (for cleanup)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import errno
 import socket
+import sys
 import unittest
 
 dummy_app = object()
@@ -310,6 +311,42 @@ class TestWSGIServer(unittest.TestCase):
         self.assertTrue(sockets[0].accepted)
         self.assertListEqual(innersock.opts, [("level", "optname", "value")])
         self.assertListEqual(L, [(inst, innersock, None, inst.adj)])
+
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "This test is not supported on Windows"
+    )
+    def test_port_bind_failure_logging(self):
+        # ensure the address is logged on a failed port bind
+
+        # create a first app correctly
+        inst_a = self._makeOne(port=8080)
+
+        # Ensure a second app correctly binds to a different host+port
+        inst_b = self._makeOne(port=8081)
+
+        # a third app should fail the bind to the fist app's host+port
+        with self.assertLogs("waitress", level="ERROR") as cm_log:
+            with self.assertRaises(OSError) as cm:
+                inst_c = self._makeOne(port=8080)
+            self.assertTrue(
+                ("[Errno 48] Address already in use" == str(cm.exception))
+                or ("[Errno 98] Address already in use" == str(cm.exception))
+            )
+
+        self.assertIn(
+            "CRITICAL:waitress:Failed bind to: ('127.0.0.1', 8080)",
+            cm_log.output,
+        )
+        self.assertTrue(
+            (
+                "CRITICAL:waitress:Exception raised: [Errno 48] Address already in use"
+                in cm_log.output
+            )
+            or (
+                "CRITICAL:waitress:Exception raised: [Errno 98] Address already in use"
+                in cm_log.output
+            )
+        )
 
 
 if hasattr(socket, "AF_UNIX"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,15 +6,11 @@ from typing import TYPE_CHECKING, List, Union
 import unittest
 
 if TYPE_CHECKING:
-    from waitress.server import BaseWSGIServer, MultiSocketServer
+    from waitress.server import BaseWSGIServer, MultiSocketServer, UnixWSGIServer
 
 dummy_app = object()
 
-
 class TestWSGIServer(unittest.TestCase):
-
-    # most tests only start a single server (for cleanup)
-    inst: Union["BaseWSGIServer", "MultiSocketServer", None]
 
     # maintain a list of instantiated servers (for cleanup)
     insts: List[Union["BaseWSGIServer", "MultiSocketServer"]]
@@ -38,7 +34,7 @@ class TestWSGIServer(unittest.TestCase):
     ):
         from waitress.server import create_server
 
-        self.inst = create_server(
+        inst = create_server(
             application,
             host=host,
             port=port,
@@ -47,8 +43,8 @@ class TestWSGIServer(unittest.TestCase):
             _start=_start,
             _sock=_sock,
         )
-        self.insts.append(self.inst)
-        return self.inst
+        self.insts.append(inst)
+        return inst
 
     def _makeOneWithMap(
         self, adj=None, _start=True, host="127.0.0.1", port=0, app=dummy_app
@@ -74,7 +70,7 @@ class TestWSGIServer(unittest.TestCase):
         map = {}
         from waitress.server import create_server
 
-        self.inst = create_server(
+        inst = create_server(
             app,
             listen=listen,
             map=map,
@@ -82,7 +78,8 @@ class TestWSGIServer(unittest.TestCase):
             _start=_start,
             _sock=sock,
         )
-        return self.inst
+        self.insts.append(inst)
+        return inst
 
     def _makeWithSockets(
         self,
@@ -99,7 +96,7 @@ class TestWSGIServer(unittest.TestCase):
         _sockets = []
         if sockets is not None:
             _sockets = sockets
-        self.inst = create_server(
+        inst = create_server(
             application,
             map=map,
             _dispatcher=_dispatcher,
@@ -107,20 +104,15 @@ class TestWSGIServer(unittest.TestCase):
             _sock=_sock,
             sockets=_sockets,
         )
-        return self.inst
+        self.insts.append(inst)
+        return inst
 
     def tearDown(self):
-        # most tests only start a single server
-        if self.inst is not None:
-            self.inst.close()
-
-        # use the list of instantiated servers
-        if self.insts:
-            for inst in self.insts:
-                inst.close()
+        # iterate the list of instantiated servers and `close()` them
+        for inst in self.insts:
+            inst.close()
 
     def test_ctor_app_is_None(self):
-        self.inst = None
         self.assertRaises(ValueError, self._makeOneWithMap, app=None)
 
     def test_ctor_start_true(self):
@@ -288,10 +280,13 @@ class TestWSGIServer(unittest.TestCase):
         from waitress.server import TcpWSGIServer, WSGIServer
 
         self.assertIs(WSGIServer, TcpWSGIServer)
-        self.inst = WSGIServer(None, _start=False, port=1234)
+        inst = WSGIServer(None, _start=False, port=1234)
         # Ensure the adjustment was actually applied.
-        self.assertNotEqual(Adjustments.port, 1234)
-        self.assertEqual(self.inst.adj.port, 1234)
+        try:
+            self.assertNotEqual(Adjustments.port, 1234)
+            self.assertEqual(inst.adj.port, 1234)
+        finally:
+            inst.close()
 
     def test_create_with_one_tcp_socket(self):
         from waitress.server import TcpWSGIServer
@@ -372,6 +367,9 @@ if hasattr(socket, "AF_UNIX"):
 
     class TestUnixWSGIServer(unittest.TestCase):
         unix_socket = "/tmp/waitress.test.sock"
+
+        # maintain a list of instantiated servers (for cleanup)
+        inst: List[Union["BaseWSGIServer", "MultiSocketServer", "UnixWSGIServer"]]
 
         def _makeOne(self, _start=True, _sock=None):
             from waitress.server import create_server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,12 +1,28 @@
 import errno
 import socket
 import sys
+from typing import TYPE_CHECKING, List, Union
 import unittest
+
+if TYPE_CHECKING:
+    from waitress.server import BaseWSGIServer, MultiSocketServer
 
 dummy_app = object()
 
 
 class TestWSGIServer(unittest.TestCase):
+
+    # most tests only start a single server (for cleanup)
+    inst: Union["BaseWSGIServer", "MultiSocketServer", None]
+
+    # maintain a list of instantiated servers (for cleanup)
+    insts: List[Union["BaseWSGIServer", "MultiSocketServer"]]
+
+    def __init__(self, *args, **kwargs):
+        # override base `__init__` to track `self.insts` for `self.tearDown`
+        super(TestWSGIServer, self).__init__(*args, **kwargs)
+        self.insts = []
+
     def _makeOne(
         self,
         application=dummy_app,
@@ -30,6 +46,7 @@ class TestWSGIServer(unittest.TestCase):
             _start=_start,
             _sock=_sock,
         )
+        self.insts.append(self.inst)
         return self.inst
 
     def _makeOneWithMap(
@@ -92,8 +109,14 @@ class TestWSGIServer(unittest.TestCase):
         return self.inst
 
     def tearDown(self):
+        # most tests only start a single server
         if self.inst is not None:
             self.inst.close()
+
+        # use the list of instantiated servers
+        if self.insts:
+            for inst in self.insts:
+                inst.close()
 
     def test_ctor_app_is_None(self):
         self.inst = None
@@ -313,10 +336,15 @@ class TestWSGIServer(unittest.TestCase):
         self.assertListEqual(L, [(inst, innersock, None, inst.adj)])
 
     @unittest.skipIf(
-        sys.platform.startswith("win"), "This test is not supported on Windows"
+        sys.platform.startswith("win"),
+        "Windows doesn't raise an exception when reusing a port",
     )
     def test_port_bind_failure_logging(self):
-        # ensure the address is logged on a failed port bind
+        """
+        Ensure the address is logged on a failed port bind.
+
+        This test was developed for #471 - logging a failed bind.
+        """
 
         # create a first app correctly
         inst_a = self._makeOne(port=8080)
@@ -328,24 +356,14 @@ class TestWSGIServer(unittest.TestCase):
         with self.assertLogs("waitress", level="ERROR") as cm_log:
             with self.assertRaises(OSError) as cm:
                 inst_c = self._makeOne(port=8080)
-            self.assertTrue(
-                ("[Errno 48] Address already in use" == str(cm.exception))
-                or ("[Errno 98] Address already in use" == str(cm.exception))
-            )
+            self.assertEqual(cm.exception.errno, errno.EADDRINUSE)
 
+        # check log for inst_c failure
         self.assertIn(
-            "CRITICAL:waitress:Failed bind to: ('127.0.0.1', 8080)",
+            "CRITICAL:waitress:"
+            "Failed bind to: `('127.0.0.1', 8080)` : "
+            "`[Errno %s] Address already in use`" % errno.EADDRINUSE,
             cm_log.output,
-        )
-        self.assertTrue(
-            (
-                "CRITICAL:waitress:Exception raised: [Errno 48] Address already in use"
-                in cm_log.output
-            )
-            or (
-                "CRITICAL:waitress:Exception raised: [Errno 98] Address already in use"
-                in cm_log.output
-            )
         )
 
 


### PR DESCRIPTION
This PR enables logging on failed port binds. See https://github.com/Pylons/waitress/issues/471

This is a continuation of #489 ; my git checkout got messed up.  (While fixing some artifacts from merging to main, I accidentally named a new working branch from `origin/feature-log_bind_failures` instead of origin's `feature-log_bind_failures`)
