### PR TITLE
fix: normalize unicode url_prefix to match PEP 3333 path encoding

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Unreleased
 Bugfix
 ~~~~~~
 
+- Waitress now normalizes a non-ASCII ``url_prefix`` to the PEP 3333
+  encoding used for request paths, so the prefix matches the parsed
+  ``PATH_INFO``/``SCRIPT_NAME``. See
+  https://github.com/Pylons/waitress/pull/493.
+
 - Renamed the HTTP header "Trailers" to "Trailer" to fix a typo and comply with
   the correct header name as specified in RFC 7230.
 

--- a/src/waitress/adjustments.py
+++ b/src/waitress/adjustments.py
@@ -75,6 +75,11 @@ def slash_fixed_str(s):
         # always have a leading slash, replace any number of leading slashes
         # with a single slash, and strip any trailing slashes
         s = "/" + s.lstrip("/").rstrip("/")
+        # Normalize encoding to match PEP 3333: WSGI PATH_INFO/SCRIPT_NAME
+        # are raw URL bytes decoded as ISO-8859-1.  Encode the user-supplied
+        # Unicode string as UTF-8 and decode as ISO-8859-1 so that non-ASCII
+        # characters compare equal to the parser-produced path.
+        s = s.encode("utf-8").decode("iso-8859-1")
     return s
 
 

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -384,6 +384,27 @@ class TestAdjustments(unittest.TestCase):
         inst = self._makeOne(ident="specific_header")
         self.assertEqual(inst.ident, "specific_header")
 
+    def test_url_prefix_unicode_normalization(self):
+        from waitress.parser import unquote_bytes_to_wsgi
+
+        # Non-ASCII url_prefix should be normalized to PEP 3333 format
+        # (UTF-8-encoded bytes decoded as ISO-8859-1) so it compares
+        # equal to the parser-produced path for the same logical path.
+        inst = self._makeOne(url_prefix="/\xfc/")  # ü as latin-1 byte
+        # \xfc (ü in latin-1) encoded as UTF-8 is \xc3\xbc.
+        # Decoded as latin-1 that gives two code points: \xc3 \xbc.
+        # Note: slash_fixed_str strips any trailing slash.
+        self.assertEqual(inst.url_prefix, "/Ã¼")
+
+        # ASCII-only url_prefix must still be unchanged.
+        inst2 = self._makeOne(url_prefix="/api")
+        self.assertEqual(inst2.url_prefix, "/api")
+
+        # Now check it matches a parser-produced path for /ü
+        raw_uri = b"/%C3%BC"
+        path = unquote_bytes_to_wsgi(raw_uri)
+        self.assertEqual(inst.url_prefix, path)
+
 
 class TestCLI(unittest.TestCase):
     def parse(self, argv):


### PR DESCRIPTION
## Summary

When `url_prefix` contains non-ASCII characters (e.g., `ü`), it fails to match the request path because the two are stored in incompatible encodings:

- The request **path** is decoded by the HTTP parser via `unquote_bytes_to_wsgi()` which percent-decodes the raw URL bytes and decodes the result as ISO-8859-1 (PEP 3333 convention).
- The **url_prefix** is stored as a plain Python `str` without encoding normalization.

This means the WSGI application receives an incorrect `PATH_INFO` — the url_prefix is never stripped — and the `SCRIPT_NAME` is not reported in the correct PEP 3333 encoding.

## Fix

Normalize the url_prefix in `slash_fixed_str` by encoding the user-supplied Unicode string as UTF-8 and then decoding as ISO-8859-1, matching the convention used by the HTTP request parser.  For ASCII-only prefixes this is a no-op.

## Testing

Added `test_url_prefix_unicode_normalization` that verifies:
1. A non-ASCII url_prefix is stored in PEP 3333 format.
2. An ASCII-only url_prefix is unchanged.
3. The normalized url_prefix equals the parser-produced path for the same logical URI.

All 794 existing tests pass (10 skipped, same as before).

Closes #492