### PR TITLE
Add a mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Delta Regeer <xistence@0x58.com> <bertjw@regeer.org>
+Delta Regeer <xistence@0x58.com> <xistence@0x58.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -133,7 +133,7 @@ Contributors
 
 - Ben Warren, 2015-05-17
 
-- Bert JW Regeer, 2015-09-23
+- Delta Regeer, 2015-09-23
 
 - Yu Zhou, 2015-09-24
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include LICENSE.txt
 include contributing.md
 include CONTRIBUTORS.txt
 include COPYRIGHT.txt
+include .mailmap
 
 include pyproject.toml
 include .coveragerc .flake8


### PR DESCRIPTION
Adds a `.mailmap` so my commits resolve to my current name and email,
and updates my `CONTRIBUTORS.txt` entry to match.

The mailmap maps by commit email, which covers every historical variant.
`.mailmap` is also added to `MANIFEST.in`, since check-manifest requires
version-controlled files to appear in the sdist.