### PR TITLE
Fix flaky functional tests on PyPy by spawning rather than forking

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -67,7 +67,6 @@ class SubprocessTests:
 
     def start_subprocess(self, target, **kw):
         # Spawn a server process.
-        self.queue = multiprocessing.Queue()
 
         if "COVERAGE_RCFILE" in os.environ:
             os.environ["COVERAGE_PROCESS_START"] = os.environ["COVERAGE_RCFILE"]
@@ -84,6 +83,15 @@ class SubprocessTests:
             ctx = multiprocessing.get_context("spawn")
         else:
             ctx = multiprocessing.get_context("fork")
+
+        # NB: the queue has to come from the same context as the process. A
+        # queue built from the default context carries a SemLock tagged with
+        # that context, and multiprocessing refuses to hand a fork-context
+        # SemLock to a spawn-context child. The default start method is
+        # platform dependent -- fork on Linux, spawn on macOS -- so taking it
+        # from multiprocessing directly happens to work on one and not on the
+        # other.
+        self.queue = ctx.Queue()
 
         self.proc = ctx.Process(
             target=start_server,

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -18,6 +18,17 @@ from waitress.utilities import cleanup_unix_socket
 dn = os.path.dirname
 here = dn(__file__)
 
+PYPY = sys.implementation.name == "pypy"
+
+# How long to wait for a freshly spawned server subprocess to bind a socket and
+# hand the address it bound to back over the queue.
+#
+# This is not the time the work takes, it is a bound on a pathological hang: on
+# success the get() returns the moment the address arrives, so a generous value
+# costs nothing. Five seconds was tight enough that a loaded machine could trip
+# it on its own.
+SERVER_START_TIMEOUT = 30
+
 
 class NullHandler(logging.Handler):  # pragma: no cover
     """A logging handler that swallows all emitted messages."""
@@ -61,10 +72,18 @@ class SubprocessTests:
         if "COVERAGE_RCFILE" in os.environ:
             os.environ["COVERAGE_PROCESS_START"] = os.environ["COVERAGE_RCFILE"]
 
-        if not WIN:
-            ctx = multiprocessing.get_context("fork")
-        else:
+        if WIN or PYPY:
+            # fork() only duplicates the calling thread, so if any other thread
+            # in this process happens to hold a lock at the moment we fork, the
+            # child inherits it already locked and with no thread left alive to
+            # release it. The child then hangs before it can report the address
+            # it bound to, and the test fails on an unrelated-looking timeout.
+            # This is timing dependent, and PyPy loses the race often enough to
+            # make the suite flaky, so pay the cost of a fresh interpreter
+            # there as we already do on Windows.
             ctx = multiprocessing.get_context("spawn")
+        else:
+            ctx = multiprocessing.get_context("fork")
 
         self.proc = ctx.Process(
             target=start_server,
@@ -76,7 +95,7 @@ class SubprocessTests:
         if self.proc.exitcode is not None:  # pragma: no cover
             raise RuntimeError("%s didn't start" % str(target))
         # Get the socket the server is listening on.
-        self.bound_to = self.queue.get(timeout=5)
+        self.bound_to = self.queue.get(timeout=SERVER_START_TIMEOUT)
         self.sock = self.create_socket()
 
     def stop_subprocess(self):

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,16 @@ envlist =
 isolated_build = True
 
 [testenv]
+# NB: coverage is disabled on PyPy. Collecting it relies on sys.settrace, which
+# turns the JIT off and makes the suite roughly three times slower, and the
+# numbers it produces disagree with CPython's, so combining them would drop the
+# coverage env below its --fail-under threshold.
 commands =
     python --version
     python -mpytest \
     pypy39: --no-cov \
     pypy310: --no-cov \
+    pypy311: --no-cov \
         {posargs:}
 extras =
     testing


### PR DESCRIPTION
The functional tests hand each server subprocess a `multiprocessing.Queue` and wait for it to post back the address it bound to. On PyPy that wait would sometimes expire, failing a different, unrelated-looking test on each run:

```
FAILED tests/test_functional.py::TcpEchoTests::test_large_body - queue.Empty
FAILED tests/test_functional.py::TcpFileWrapperTests::test_notfilelike_http10 - queue.Empty
FAILED tests/test_functional.py::UnixTooLargeTests::test_request_body_too_large_chunked_encoding - queue.Empty
```

On this machine `pypy311` failed 5 runs out of 8. It reproduces on `main` with no other changes, so it is not new.

## Cause

The `fork` start method. `fork()` only duplicates the calling thread, so if any other thread in the pytest process happens to hold a lock at the moment we fork, the child inherits it already locked with no thread left alive to release it. The child then hangs before it can report its address, and the test fails on a timeout that points at the wrong thing. It is a race, which is why the failing test moved around each run.

It is worth being explicit that **this is not slowness**. My first attempt was to raise the timeout, on the assumption that PyPy's interpreter startup was simply losing to a tight 5 second bound. That is wrong — with a 30 second bound it still came back empty, having waited the full 30 seconds:

```
tests/test_functional.py:91: in start_subprocess
    self.bound_to = self.queue.get(timeout=SERVER_START_TIMEOUT)
...
timeout = 29.999992083059624
>                       raise Empty
E                       queue.Empty
```

A child that has not posted after 30 seconds is hung, not late.

## Fix

Use the `spawn` start method on PyPy, as we already do on Windows. The Windows path is what keeps the fixture apps spawn-safe today, so nothing else needed changing. It costs a fresh interpreter per server, which is why CPython keeps `fork`.

The timeout constant is kept and lifted to 30s regardless. It only bounds a pathological hang — on success the `get()` returns the moment the address arrives — and 5s was tight enough that a loaded machine could trip it on its own.

Also disables coverage on `pypy311`, matching the existing `pypy39` and `pypy310` lines. Two reasons beyond consistency: coverage relies on `sys.settrace`, which turns the JIT off and makes the suite roughly 3x slower (~31s to ~12s), and PyPy's numbers disagree with CPython's — `pypy311` was reporting `wasyncore.py` at 99.14% against CPython's 100%, which drags the combined report under the `coverage` env's `--fail-under=100`.

Note `pypy39` and `pypy310` were on the same `fork` path and were presumably flaky too; the check is `PYPY` rather than a version, so they are covered.

## Verification

`pypy311` alone, 8 consecutive runs: 8 passed, 0 failed (previously 3 of 8).

All three PyPy envs, 4 consecutive rounds: green every time.

Full default `tox` envlist — `lint`, `py39` through `py314`, `pypy39`, `pypy310`, `pypy311`, `coverage` (with its `--fail-under=100` gate), and `docs` — all OK.

No change to Waitress itself, so there is no changelog entry; this is test infrastructure only.