### PR TITLE
Don't crash the loop when select hits EBADF after close()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Unreleased
 Bugfix
 ~~~~~~
 
+- Ignore ``EBADF`` from ``select``/``poll`` when a socket is closed while
+  the server is waiting for I/O, instead of crashing the worker loop.
+  See https://github.com/Pylons/waitress/issues/468
+
 - Renamed the HTTP header "Trailers" to "Trailer" to fix a typo and comply with
   the correct header name as specified in RFC 7230.
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -154,3 +154,5 @@ Contributors
 - Arun Raghunath, 2026-03-13
 
 - Rui Xi, 2026-03-20
+
+- Gyanu, 2026-08-30

--- a/src/waitress/wasyncore.py
+++ b/src/waitress/wasyncore.py
@@ -166,10 +166,10 @@ def poll(timeout=0.0, map=None):
         try:
             r, w, e = select.select(r, w, e, timeout)
         except OSError as err:
-            if err.args[0] != EINTR:
-                raise
-            else:
+            # close() from another thread can leave a stale fd in the set
+            if err.args[0] in (EINTR, EBADF):
                 return
+            raise
 
         for fd in r:
             obj = map.get(fd)
@@ -212,9 +212,9 @@ def poll2(timeout=0.0, map=None):
         try:
             r = pollster.poll(timeout)
         except OSError as err:
-            if err.args[0] != EINTR:
-                raise
-            r = []
+            if err.args[0] in (EINTR, EBADF):
+                return
+            raise
 
         for fd, flags in r:
             obj = map.get(fd)

--- a/tests/test_wasyncore.py
+++ b/tests/test_wasyncore.py
@@ -1353,9 +1353,25 @@ class Test_poll(unittest.TestCase):
         self.assertIsNone(result)
         self.assertListEqual(dummy_select.selected, [([0], [], [0], 0.0)])
 
+    def test_select_raises_EBADF(self):
+        dummy_select = DummySelect(select.error(errno.EBADF))
+        disp = DummyDispatcher()
+        disp.readable = lambda: True
+        map = {0: disp}
+        try:
+            from waitress import wasyncore
+
+            old_select = wasyncore.select
+            wasyncore.select = dummy_select
+            result = self._callFUT(map=map)
+        finally:
+            wasyncore.select = old_select
+        self.assertIsNone(result)
+        self.assertListEqual(dummy_select.selected, [([0], [], [0], 0.0)])
+
     def test_select_raises_non_EINTR(self):
         # i read the mock.patch docs.  nerp.
-        dummy_select = DummySelect(select.error(errno.EBADF))
+        dummy_select = DummySelect(select.error(errno.EPERM))
         disp = DummyDispatcher()
         disp.readable = lambda: True
         map = {0: disp}
@@ -1392,9 +1408,24 @@ class Test_poll2(unittest.TestCase):
             wasyncore.select = old_select
         self.assertListEqual(pollster.polled, [0.0])
 
+    def test_select_raises_EBADF(self):
+        pollster = DummyPollster(exc=select.error(errno.EBADF))
+        dummy_select = DummySelect(pollster=pollster)
+        disp = DummyDispatcher()
+        map = {0: disp}
+        try:
+            from waitress import wasyncore
+
+            old_select = wasyncore.select
+            wasyncore.select = dummy_select
+            self._callFUT(map=map)
+        finally:
+            wasyncore.select = old_select
+        self.assertListEqual(pollster.polled, [0.0])
+
     def test_select_raises_non_EINTR(self):
         # i read the mock.patch docs.  nerp.
-        pollster = DummyPollster(exc=select.error(errno.EBADF))
+        pollster = DummyPollster(exc=select.error(errno.EPERM))
         dummy_select = DummySelect(pollster=pollster)
         disp = DummyDispatcher()
         map = {0: disp}


### PR DESCRIPTION
`TcpWSGIServer.close()` from another thread races with `select()`. The closed fd is still in the interest set, so you get EBADF and the worker loop dies.

Same treatment as EINTR — just go around again.

Fixes #468
